### PR TITLE
Invoke a simpler UseMvc overload in Razor Pages templates

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Startup.cs
@@ -129,12 +129,7 @@ namespace Company.WebApplication1
             app.UseAuthentication();
 
 #endif
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller}/{action=Index}/{id?}");
-            });
+            app.UseMvcWithDefaultRoute();
         }
     }
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Startup.cs
@@ -129,7 +129,7 @@ namespace Company.WebApplication1
             app.UseAuthentication();
 
 #endif
-            app.UseMvcWithDefaultRoute();
+            app.UseMvc();
         }
     }
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.1/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.1/content/RazorPagesWeb-CSharp/Startup.cs
@@ -129,12 +129,7 @@ namespace Company.WebApplication1
             app.UseAuthentication();
 
 #endif
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller}/{action=Index}/{id?}");
-            });
+            app.UseMvcWithDefaultRoute();
         }
     }
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.1/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.1/content/RazorPagesWeb-CSharp/Startup.cs
@@ -129,7 +129,7 @@ namespace Company.WebApplication1
             app.UseAuthentication();
 
 #endif
-            app.UseMvcWithDefaultRoute();
+            app.UseMvc();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/templating/issues/31.

My assumption is that we only want to apply this change to the Razor Pages project templates. It's Razor Pages, after all, that's intended to lower the barrier to entry.

/cc: @Rick-Anderson @DamianEdwards @rynowak 