### PR TITLE
Ensure SPA templates run `npm install` prior to webpack build

### DIFF
--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/AngularSpa.csproj
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/AngularSpa.csproj
@@ -35,6 +35,9 @@
     </Exec>
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
 
+    <!-- Ensure NPM packages are installed -->
+    <Exec Command="npm install" />
+
     <!-- In development, the dist files won't exist on the first run or when cloning to
          a different machine, so rebuild them if not already present. -->
     <Message Importance="high" Text="Performing first-run Webpack build..." />

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/ReactSpa.csproj
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/ReactSpa.csproj
@@ -30,6 +30,9 @@
     </Exec>
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
 
+    <!-- Ensure NPM packages are installed -->
+    <Exec Command="npm install" />
+    
     <!-- In development, the dist files won't exist on the first run or when cloning to
          a different machine, so rebuild them if not already present. -->
     <Message Importance="high" Text="Performing first-run Webpack build..." />

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ReactReduxSpa.csproj
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ReactReduxSpa.csproj
@@ -35,6 +35,9 @@
     </Exec>
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
 
+    <!-- Ensure NPM packages are installed -->
+    <Exec Command="npm install" />
+    
     <!-- In development, the dist files won't exist on the first run or when cloning to
          a different machine, so rebuild them if not already present. -->
     <Message Importance="high" Text="Performing first-run Webpack build..." />


### PR DESCRIPTION
Update SPA templates to make sure `npm install` is run as a pre-build step

Addresses #56 