### PR TITLE
Porting the `ASP.NET Core Empty` template from C# to VB

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/.template.config/template.json
@@ -1,0 +1,39 @@
+{  
+   "author": "Andre Obelink & Matthijs ter Woord",
+   "classifications": ["Web", "Empty"],
+   "name": "ASP.NET Core Empty",
+   "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
+   "groupIdentity": "Microsoft.Web.Empty",   
+   "precedence": "2000",
+   "identity": "Microsoft.Web.Empty.VB.2.0",
+   "shortName": "web",
+   "thirdPartyNotices": "https://aka.ms/template-3pn",
+   "tags": {
+     "language": "VB",
+     "type": "project"
+   },
+   "sourceName": "Company.WebApplication1",
+   "preferNameDirectory": true,
+   "guids": [
+     "53bc9b9d-9d6a-45d4-8429-2a2761773502"
+   ],
+  "primaryOutputs": [
+    {
+      "path": "Company.WebApplication1.vbproj"
+    }
+  ],
+  "defaultName": "WebApplication1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/Company.WebApplication1.vbproj
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/Company.WebApplication1.vbproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web" ToolsVersion="15.0">
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/Program.vb
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/Program.vb
@@ -1,0 +1,20 @@
+﻿Imports System.Collections.Generic
+Imports System.IO
+Imports System.Linq
+Imports System.Threading.Tasks
+Imports Microsoft.AspNetCore
+Imports Microsoft.AspNetCore.Hosting
+Imports Microsoft.Extensions.Configuration
+Imports Microsoft.Extensions.Logging
+
+Namespace Company.WebApplication1
+	Public Class Program
+		Public Shared Sub Main(args As String())
+			BuildWebHost(args).Run()
+		End Sub
+
+		Public Shared Function BuildWebHost(args As String()) As IWebHost
+			Return WebHost.CreateDefaultBuilder(args).UseStartup(Of Startup)().Build()
+		End Function
+	End Class
+End Namespace

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/Startup.vb
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-VB/Startup.vb
@@ -1,0 +1,27 @@
+﻿Imports System.Collections.Generic
+Imports System.Linq
+Imports System.Threading.Tasks
+Imports Microsoft.AspNetCore.Builder
+Imports Microsoft.AspNetCore.Hosting
+Imports Microsoft.AspNetCore.Http
+Imports Microsoft.Extensions.DependencyInjection
+
+Namespace Company.WebApplication1
+	Public Class Startup
+		' This method gets called by the runtime. Use this method to add services to the container.
+		' For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+		Public Sub ConfigureServices(services As IServiceCollection)
+		End Sub
+
+		' This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+		Public Sub Configure(app As IApplicationBuilder, env As IHostingEnvironment)
+			If env.IsDevelopment() Then
+				app.UseDeveloperExceptionPage()
+			End If
+
+			app.Run(Async Function(context) 
+				              Await context.Response.WriteAsync("Hello World!")
+						  End Function)
+		End Sub
+	End Class
+End Namespace


### PR DESCRIPTION
This PR is not yet complete.

Pieces we know for sure are missing:
1. Optional placeholders in template
2. Overridable ASP.NET Core version. 
3. Many elements from template.json. We're not sure of all the options in the C# version of the template.json.
4. Integration in build script

This version is a first draft version. We hope to gather feedback in order to get VB version(s) of the templates working. 