### PR TITLE
Revert changes to the 2.0 templates that were unintentionally copied from dotnet/templating

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Account/Manage/TwoFactorAuthentication.cshtml.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Account/Manage/TwoFactorAuthentication.cshtml.cs
@@ -12,6 +12,8 @@ namespace Company.WebApplication1.Pages.Account.Manage
 {
     public class TwoFactorAuthenticationModel : PageModel
     {
+        private const string AuthenicatorUriFormat = "otpauth://totp/{0}:{1}?secret={2}&issuer={0}";
+
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly ILogger<TwoFactorAuthenticationModel> _logger;

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Data/Migrations/00000000000000_CreateIdentitySchema.Designer.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Data/Migrations/00000000000000_CreateIdentitySchema.Designer.cs
@@ -17,85 +17,17 @@ namespace Company.WebApplication1.Data.Migrations
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
-#pragma warning disable 612, 618
             modelBuilder
 #if (UseLocalDB)
-                .HasAnnotation("ProductVersion", "2.0.0-rtm-26452")
+                .HasAnnotation("ProductVersion", "1.0.0-rc3")
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 #else
-                .HasAnnotation("ProductVersion", "2.0.0-rtm-26452");
+                .HasAnnotation("ProductVersion", "1.0.2");
 #endif
-
-            modelBuilder.Entity("Company.WebApplication1.Models.ApplicationUser", b =>
-                {
-                    b.Property<string>("Id")
-                        .ValueGeneratedOnAdd();
-
-                    b.Property<int>("AccessFailedCount");
-
-                    b.Property<string>("ConcurrencyStamp")
-                        .IsConcurrencyToken();
-
-                    b.Property<string>("Email")
-#if (UseLocalDB)
-                        .HasAnnotation("MaxLength", 256);
-#else
-                        .HasMaxLength(256);
-#endif
-
-                    b.Property<bool>("EmailConfirmed");
-
-                    b.Property<bool>("LockoutEnabled");
-
-                    b.Property<DateTimeOffset?>("LockoutEnd");
-
-                    b.Property<string>("NormalizedEmail")
-#if (UseLocalDB)
-                        .HasAnnotation("MaxLength", 256);
-#else
-                        .HasMaxLength(256);
-#endif
-
-                    b.Property<string>("NormalizedUserName")
-#if (UseLocalDB)
-                        .HasAnnotation("MaxLength", 256);
-#else
-                        .HasMaxLength(256);
-#endif
-
-                    b.Property<string>("PasswordHash");
-
-                    b.Property<string>("PhoneNumber");
-
-                    b.Property<bool>("PhoneNumberConfirmed");
-
-                    b.Property<string>("SecurityStamp");
-
-                    b.Property<bool>("TwoFactorEnabled");
-
-                    b.Property<string>("UserName")
-#if (UseLocalDB)
-                        .HasAnnotation("MaxLength", 256);
-#else
-                        .HasMaxLength(256);
-#endif
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("NormalizedEmail")
-                        .HasName("EmailIndex");
-
-                    b.HasIndex("NormalizedUserName")
-                        .IsUnique()
-                        .HasName("UserNameIndex");
-
-                    b.ToTable("AspNetUsers");
-                });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
-                    b.Property<string>("Id")
-                        .ValueGeneratedOnAdd();
+                    b.Property<string>("Id");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken();
@@ -117,7 +49,6 @@ namespace Company.WebApplication1.Data.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedName")
-                        .IsUnique()
                         .HasName("RoleNameIndex");
 
                     b.ToTable("AspNetRoles");
@@ -189,6 +120,8 @@ namespace Company.WebApplication1.Data.Migrations
 
                     b.HasIndex("RoleId");
 
+                    b.HasIndex("UserId");
+
                     b.ToTable("AspNetUserRoles");
                 });
 
@@ -207,10 +140,75 @@ namespace Company.WebApplication1.Data.Migrations
                     b.ToTable("AspNetUserTokens");
                 });
 
+            modelBuilder.Entity("Company.WebApplication1.Models.ApplicationUser", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+#if (UseLocalDB)
+                        .HasAnnotation("MaxLength", 256);
+#else
+                        .HasMaxLength(256);
+#endif
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("NormalizedEmail")
+#if (UseLocalDB)
+                        .HasAnnotation("MaxLength", 256);
+#else
+                        .HasMaxLength(256);
+#endif
+
+                    b.Property<string>("NormalizedUserName")
+#if (UseLocalDB)
+                        .HasAnnotation("MaxLength", 256);
+#else
+                        .HasMaxLength(256);
+#endif
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+#if (UseLocalDB)
+                        .HasAnnotation("MaxLength", 256);
+#else
+                        .HasMaxLength(256);
+#endif
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasName("EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .IsUnique()
+                        .HasName("UserNameIndex");
+
+                    b.ToTable("AspNetUsers");
+                });
+
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
                 {
                     b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole")
-                        .WithMany()
+                        .WithMany("Claims")
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
@@ -218,7 +216,7 @@ namespace Company.WebApplication1.Data.Migrations
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
                 {
                     b.HasOne("Company.WebApplication1.Models.ApplicationUser")
-                        .WithMany()
+                        .WithMany("Claims")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
@@ -226,7 +224,7 @@ namespace Company.WebApplication1.Data.Migrations
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
                 {
                     b.HasOne("Company.WebApplication1.Models.ApplicationUser")
-                        .WithMany()
+                        .WithMany("Logins")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
@@ -234,24 +232,15 @@ namespace Company.WebApplication1.Data.Migrations
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
                 {
                     b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole")
-                        .WithMany()
+                        .WithMany("Users")
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade);
 
                     b.HasOne("Company.WebApplication1.Models.ApplicationUser")
-                        .WithMany()
+                        .WithMany("Roles")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade);
                 });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
-                {
-                    b.HasOne("Company.WebApplication1.Models.ApplicationUser")
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade);
-                });
-#pragma warning restore 612, 618
         }
     }
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Data/Migrations/00000000000000_CreateIdentitySchema.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Data/Migrations/00000000000000_CreateIdentitySchema.cs
@@ -39,12 +39,6 @@ namespace Company.WebApplication1.Data.Migrations
                 constraints: table =>
                 {
                     table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
-                    table.ForeignKey(
-                        name: "FK_AspNetUserTokens_AspNetUsers_UserId",
-                        column: x => x.UserId,
-                        principalTable: "AspNetUsers",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateTable(
@@ -169,8 +163,7 @@ namespace Company.WebApplication1.Data.Migrations
             migrationBuilder.CreateIndex(
                 name: "RoleNameIndex",
                 table: "AspNetRoles",
-                column: "NormalizedName",
-                unique: true);
+                column: "NormalizedName");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AspNetRoleClaims_RoleId",
@@ -191,6 +184,11 @@ namespace Company.WebApplication1.Data.Migrations
                 name: "IX_AspNetUserRoles_RoleId",
                 table: "AspNetUserRoles",
                 column: "RoleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUserRoles_UserId",
+                table: "AspNetUserRoles",
+                column: "UserId");
 
             migrationBuilder.CreateIndex(
                 name: "EmailIndex",


### PR DESCRIPTION
Reverts changes to Microsoft.DotNet.Web.ProjectTemplates.2.0 that were made after https://github.com/dotnet/templating/tree/6e22c1178c7ddd6e28e5b5e85f449e632f6bbe93/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0 

Aka, undo https://github.com/dotnet/templating/pull/1212 on 2.0 templates. The fix remains in 2.1 templates.