### PR TITLE
Remove remaining Bower references. Fixes #161.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ packages/
 artifacts/
 PublishProfiles/
 .vs/
-bower_components/
 node_modules/
 debugSettings.json
 project.lock.json

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Index.cshtml
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Pages/Index.cshtml
@@ -38,7 +38,7 @@
             <img src="~/images/banner3.svg" alt="Package Management" class="img-responsive" />
             <div class="carousel-caption" role="option">
                 <p>
-                    Bring in libraries from NuGet, Bower, and npm, and automate tasks using Grunt or Gulp.
+                    Bring in libraries from NuGet and npm, and automate tasks using Grunt or Gulp.
                     <a class="btn btn-default" href="https://go.microsoft.com/fwlink/?LinkID=525029&clcid=0x409">
                         Learn More
                     </a>
@@ -72,7 +72,6 @@
         <h2>Application uses</h2>
         <ul>
             <li>Sample pages using ASP.NET Core Razor Pages</li>
-            <li><a href="https://go.microsoft.com/fwlink/?LinkId=518004">Bower</a> for managing client-side libraries</li>
             <li>Theming using <a href="https://go.microsoft.com/fwlink/?LinkID=398939">Bootstrap</a></li>
         </ul>
     </div>
@@ -83,7 +82,6 @@
             <li><a href="https://go.microsoft.com/fwlink/?LinkId=699315">Manage User Secrets using Secret Manager.</a></li>
             <li><a href="https://go.microsoft.com/fwlink/?LinkId=699316">Use logging to log a message.</a></li>
             <li><a href="https://go.microsoft.com/fwlink/?LinkId=699317">Add packages using NuGet.</a></li>
-            <li><a href="https://go.microsoft.com/fwlink/?LinkId=699318">Add client packages using Bower.</a></li>
             <li><a href="https://go.microsoft.com/fwlink/?LinkId=699319">Target development, staging or production environment.</a></li>
         </ul>
     </div>


### PR DESCRIPTION
I know this is so trivial that there's not much to review, so I'll merge it after a day if there are no specific objections.

As for why to remove `bower_components/` from the repo's top-level `.gitignore`, we shouldn't be using Bower in any way during development, so if somehow some new Bower files ended up in our local working copies, it would be preferable to have that highlighted from the fact that they'd now show up in Git diffs.