### PR TITLE
Add launchSettings.json by default to our templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ nuget.exe
 *.sln.ide
 node_modules
 **/[Cc]ompiler/[Rr]esources/**/*.js
-*launchSettings.json
 .build/
 .testPublish/
 .vscode

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,9 @@
     <MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>
     <MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion>
     <MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>
+    <MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion>
     <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>
+    <MicrosoftAspNetCoreHttpsPolicyPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreHttpsPolicyPackageVersion>
     <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
     <MicrosoftAspNetCoreMvcPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreMvcPackageVersion>
     <MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion>2.1.0-preview1-27644</MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion>
@@ -35,9 +37,9 @@
     <MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion>2.1.0-preview1-27644</MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion>
     <NETStandardLibraryPackageVersion>2.0.0</NETStandardLibraryPackageVersion>
     <SeleniumFirefoxWebDriverPackageVersion>0.19.0</SeleniumFirefoxWebDriverPackageVersion>
-    <SeleniumSupportPackageVersion>3.6.0</SeleniumSupportPackageVersion>
+    <SeleniumSupportPackageVersion>3.7.0</SeleniumSupportPackageVersion>
     <SeleniumWebDriverMicrosoftDriverPackageVersion>16.16299.0</SeleniumWebDriverMicrosoftDriverPackageVersion>
-    <SeleniumWebDriverPackageVersion>3.6.0</SeleniumWebDriverPackageVersion>
+    <SeleniumWebDriverPackageVersion>3.7.0</SeleniumWebDriverPackageVersion>
     <SystemSecurityPermissionsPackageVersion>4.4.0</SystemSecurityPermissionsPackageVersion>
     <XunitAnalyzersPackageVersion>0.7.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.0</XunitPackageVersion>

--- a/src/Microsoft.AspNetCore.SpaTemplates/Aurelia-CSharp.csproj.in
+++ b/src/Microsoft.AspNetCore.SpaTemplates/Aurelia-CSharp.csproj.in
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />

--- a/src/Microsoft.AspNetCore.SpaTemplates/Knockout-CSharp.csproj.in
+++ b/src/Microsoft.AspNetCore.SpaTemplates/Knockout-CSharp.csproj.in
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />

--- a/src/Microsoft.AspNetCore.SpaTemplates/Microsoft.AspNetCore.SpaTemplates.csproj
+++ b/src/Microsoft.AspNetCore.SpaTemplates/Microsoft.AspNetCore.SpaTemplates.csproj
@@ -13,6 +13,7 @@
     <GeneratedContentProperties>
       MicrosoftAspNetCoreAllPackageVersion=$(MicrosoftAspNetCoreAllPackageVersion);
       MicrosoftAspNetCoreMvcPackageVersion=$(MicrosoftAspNetCoreMvcPackageVersion);
+      MicrosoftAspNetCoreHttpsPolicyPackageVersion=$(MicrosoftAspNetCoreHttpsPolicyPackageVersion);
       MicrosoftAspNetCorePackageVersion=$(MicrosoftAspNetCorePackageVersion);
       MicrosoftAspNetCoreSpaServicesPackageVersion=$(MicrosoftAspNetCoreSpaServicesPackageVersion);
       MicrosoftAspNetCoreStaticFilesPackageVersion=$(MicrosoftAspNetCoreStaticFilesPackageVersion);

--- a/src/Microsoft.AspNetCore.SpaTemplates/Vue-CSharp.csproj.in
+++ b/src/Microsoft.AspNetCore.SpaTemplates/Vue-CSharp.csproj.in
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,16 @@
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""
+    },
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
     }
   }
 }

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/.template.config/template.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/.template.config/template.json
@@ -22,10 +22,64 @@
       "target": "./",
       "exclude": [
         ".template.config/**"
+      ],
+      "modifiers": [
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
+        }
       ]
     }
   ],
   "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "TargetFrameworkOverride": {
       "type": "parameter",
       "description": "Overrides the target framework",

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/.template.config/vs-2017.3.host.json
@@ -16,5 +16,12 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "ports": [
+    {
+      "name": "HttpsPort",
+      "useHttps": true
+    }
+  ],
+  "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/Startup.cs
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Aurelia-CSharp/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.SpaServices.Webpack;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,8 +40,10 @@ namespace AureliaSpa
             else
             {
                 app.UseExceptionHandler("/Home/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
             app.UseMvc(routes =>

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,16 @@
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""
+    },
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
     }
   }
 }

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/.template.config/template.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/.template.config/template.json
@@ -22,10 +22,64 @@
       "target": "./",
       "exclude": [
         ".template.config/**"
+      ],
+      "modifiers": [
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
+        }
       ]
     }
   ],
   "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "TargetFrameworkOverride": {
       "type": "parameter",
       "description": "Overrides the target framework",

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/.template.config/vs-2017.3.host.json
@@ -16,5 +16,12 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "ports": [
+    {
+      "name": "HttpsPort",
+      "useHttps": true
+    }
+  ],
+  "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/Startup.cs
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.SpaServices.Webpack;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,8 +40,10 @@ namespace KnockoutSpa
             else
             {
                 app.UseExceptionHandler("/Home/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
             app.UseMvc(routes =>

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,16 @@
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""
+    },
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
     }
   }
 }

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/.template.config/template.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/.template.config/template.json
@@ -22,10 +22,64 @@
       "target": "./",
       "exclude": [
         ".template.config/**"
+      ],
+      "modifiers": [
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
+        }
       ]
     }
   ],
   "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "TargetFrameworkOverride": {
       "type": "parameter",
       "description": "Overrides the target framework",

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/.template.config/vs-2017.3.host.json
@@ -16,5 +16,12 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "ports": [
+    {
+      "name": "HttpsPort",
+      "useHttps": true
+    }
+  ],
+  "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/Startup.cs
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Vue-CSharp/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.SpaServices.Webpack;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,8 +40,10 @@ namespace VueSpa
             else
             {
                 app.UseExceptionHandler("/Home/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
             app.UseMvc(routes =>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -18,6 +18,7 @@
       MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion=$(MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion);
       MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion=$(MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion);
       MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion=$(MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion);
+      MicrosoftAspNetCoreHttpsPolicyPackageVersion=$(MicrosoftAspNetCoreHttpsPolicyPackageVersion);
       MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion=$(MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion);
       MicrosoftAspNetCoreMvcPackageVersion=$(MicrosoftAspNetCoreMvcPackageVersion);
       MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion=$(MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion);

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}" Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="${MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="${MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion}" PrivateAssets="All" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}" Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="${MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="${MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion}" PrivateAssets="All" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -21,6 +21,7 @@
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="${MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True' OR '$(IndividualB2CAuth)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -13,14 +13,14 @@
       "longName": "no-restore",
       "shortName": ""
     },
-    "KestrelPort": {
+    "HttpPort": {
       "isHidden": true
     },
-    "IISExpressPort": {
+    "HttpsPort": {
       "isHidden": true
     },
-    "IncludeLaunchSettings": {
-      "longName": "use-launch-settings",
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
       "shortName": ""
     },
     "RuntimeFrameworkVersion": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -26,7 +26,7 @@
     {
       "modifiers": [
         {
-          "condition": "(!IncludeLaunchSettings)",
+          "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
           ]
@@ -41,47 +41,51 @@
       "datatype": "string",
       "defaultValue": "2.1.0-preview2-25624-02"
     },
-    "IncludeLaunchSettings": {
+    "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Whether to include launchSettings.json in the generated template."
+      "description": "Whether to exclude launchSettings.json from the generated template."
     },
-    "KestrelPort": {
+    "HttpPort": {
       "type": "parameter",
       "datatype": "integer",
-      "description": "Port number to use to configure Kestrel in launchSettings.json."
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
     },
-    "KestrelPortGenerated": {
+    "HttpPortGenerated": {
       "type": "generated",
       "generator": "port"
     },
-    "KestrelPortReplacer": {
+    "HttpPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "KestrelPort",
-        "fallbackVariableName": "KestrelPortGenerated"
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
       },
-      "replaces": "5000"
+      "replaces": "8080"
     },
-    "IISExpressPort": {
+    "HttpsPort": {
       "type": "parameter",
       "datatype": "integer",
-      "description": "Port number to use to configure IIS Express in launchSettings.json."
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
     },
-    "IISExpressPortGenerated": {
+    "HttpsPortGenerated": {
       "type": "generated",
-      "generator": "port"
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
     },
-    "IISExpressPortReplacer": {
+    "HttpsPortReplacer": {
       "type": "generated",
       "generator": "coalesce",
       "parameters": {
-        "sourceVariableName": "IISExpressPort",
-        "fallbackVariableName": "IISExpressPortGenerated"
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
       },
-      "replaces": "55556"
+      "replaces": "44300"
     },
     "TargetFrameworkOverride": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -18,14 +18,10 @@
   "legacyTemplateIdentity": "Microsoft.NetCore.CSharp.EmptyWeb",
   "ports": [
     {
-      "name": "IISExpressPort",
-      "useHttps": false
-    },
-    {
-      "name": "KestrelPort",
-      "useHttps": false
+      "name": "HttpsPort",
+      "useHttps": true
     }
   ],
-  "includeLaunchSettings": true,
+  "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
@@ -56,17 +56,14 @@
       "isHidden": "true",
       "longName": "no-tools"
     },
+    "HttpPort": {
+      "isHidden": true
+    },
     "HttpsPort": {
       "isHidden": true
     },
-    "KestrelPort": {
-      "isHidden": true
-    },
-    "IISExpressPort": {
-      "isHidden": true
-    },
-    "IncludeLaunchSettings": {
-      "longName": "use-launch-settings",
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
       "shortName": ""
     },
     "UserSecretsId": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -74,7 +74,7 @@
           ]
         },
         {
-          "condition": "(!IncludeLaunchSettings && !WindowsAuth)",
+          "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
           ]
@@ -207,11 +207,11 @@
       "defaultValue": "aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502",
       "description": "The ID to use for secrets (use with OrgReadAccess or Individual auth)."
     },
-    "IncludeLaunchSettings": {
+    "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Whether to include launchSettings.json in the generated template."
+      "description": "Whether to exclude launchSettings.json in the generated template."
     },
     "skipRestore": {
       "type": "parameter",
@@ -225,10 +225,28 @@
       "defaultValue": "false",
       "description": "Whether or not to include BrowserLink in the project"
     },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
     "HttpsPort": {
       "type": "parameter",
       "datatype": "integer",
-      "description": "Port number to use to configure SSL in launchSettings.json."
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
     },
     "HttpsPortGenerated": {
       "type": "generated",
@@ -245,43 +263,7 @@
         "sourceVariableName": "HttpsPort",
         "fallbackVariableName": "HttpsPortGenerated"
       },
-      "replaces": "43434"
-    },
-    "KestrelPort": {
-      "type": "parameter",
-      "datatype": "integer",
-      "description": "Port number to use to configure Kestrel in launchSettings.json."
-    },
-    "KestrelPortGenerated": {
-      "type": "generated",
-      "generator": "port"
-    },
-    "KestrelPortReplacer": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "KestrelPort",
-        "fallbackVariableName": "KestrelPortGenerated"
-      },
-      "replaces": "5001"
-    },
-    "IISExpressPort": {
-      "type": "parameter",
-      "datatype": "integer",
-      "description": "Port number to use to configure IIS Express in launchSettings.json."
-    },
-    "IISExpressPortGenerated": {
-      "type": "generated",
-      "generator": "port"
-    },
-    "IISExpressPortReplacer": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "IISExpressPort",
-        "fallbackVariableName": "IISExpressPortGenerated"
-      },
-      "replaces": "55556"
+      "replaces": "44300"
     },
     "OrganizationalAuth": {
       "type": "computed",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -51,19 +51,11 @@
   ],
   "ports": [
     {
-      "name": "IISExpressPort",
-      "useHttps": false
-    },
-    {
-      "name": "KestrelPort",
-      "useHttps": false
-    },
-    {
       "name": "HttpsPort",
       "useHttps": true
     }
   ],
+  "excludeLaunchSettings": false,
   "azureReplyUrlPortName": "HttpsPort",
-  "includeLaunchSettings": true,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/Startup.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Http;
 #endif
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 #if (OrganizationalAuth)
 using Microsoft.AspNetCore.Mvc.Authorization;
 #endif
@@ -121,8 +122,10 @@ namespace Company.WebApplication1
             else
             {
                 app.UseExceptionHandler("/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
 #if (OrganizationalAuth || IndividualAuth)

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -60,17 +60,14 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "HttpPort": {
+      "isHidden": true
+    },
     "HttpsPort": {
       "isHidden": true
     },
-    "KestrelPort": {
-      "isHidden": true
-    },
-    "IISExpressPort": {
-      "isHidden": true
-    },
-    "IncludeLaunchSettings": {
-      "longName": "use-launch-settings",
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
       "shortName": ""
     },
     "UserSecretsId": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -47,7 +47,7 @@
           ]
         },
         {
-          "condition": "(!IncludeLaunchSettings && !WindowsAuth)",
+          "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
           ]
@@ -181,11 +181,11 @@
       "defaultValue": "aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502",
       "description": "The ID to use for secrets (use with OrgReadAccess or Individual auth)."
     },
-    "IncludeLaunchSettings": {
+    "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Whether to include launchSettings.json in the generated template."
+      "description": "Whether to exclude launchSettings.json from the generated template."
     },
     "UseBrowserLink": {
       "type": "parameter",
@@ -193,10 +193,28 @@
       "defaultValue": "false",
       "description": "Whether or not to include BrowserLink in the project"
     },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
     "HttpsPort": {
       "type": "parameter",
       "datatype": "integer",
-      "description": "Port number to use to configure SSL in launchSettings.json."
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
     },
     "HttpsPortGenerated": {
       "type": "generated",
@@ -213,43 +231,7 @@
         "sourceVariableName": "HttpsPort",
         "fallbackVariableName": "HttpsPortGenerated"
       },
-      "replaces": "43434"
-    },
-    "KestrelPort": {
-      "type": "parameter",
-      "datatype": "integer",
-      "description": "Port number to use to configure Kestrel in launchSettings.json."
-    },
-    "KestrelPortGenerated": {
-      "type": "generated",
-      "generator": "port"
-    },
-    "KestrelPortReplacer": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "KestrelPort",
-        "fallbackVariableName": "KestrelPortGenerated"
-      },
-      "replaces": "5001"
-    },
-    "IISExpressPort": {
-      "type": "parameter",
-      "datatype": "integer",
-      "description": "Port number to use to configure IIS Express in launchSettings.json."
-    },
-    "IISExpressPortGenerated": {
-      "type": "generated",
-      "generator": "port"
-    },
-    "IISExpressPortReplacer": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "IISExpressPort",
-        "fallbackVariableName": "IISExpressPortGenerated"
-      },
-      "replaces": "55556"
+      "replaces": "44300"
     },
     "OrganizationalAuth": {
       "type": "computed",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -51,19 +51,11 @@
   ],
   "ports": [
     {
-      "name": "IISExpressPort",
-      "useHttps": false
-    },
-    {
-      "name": "KestrelPort",
-      "useHttps": false
-    },
-    {
       "name": "HttpsPort",
       "useHttps": true
     }
   ],
+  "excludeLaunchSettings": false,
   "azureReplyUrlPortName": "HttpsPort",
-  "includeLaunchSettings": true,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Startup.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 #endif
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 #if (OrganizationalAuth && OrgReadAccess)
@@ -95,8 +96,10 @@ namespace Company.WebApplication1
             else
             {
                 app.UseExceptionHandler("/Home/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
 
 #if (OrganizationalAuth || IndividualAuth)

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -1,6 +1,16 @@
 {
 "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
+    },
     "TargetFrameworkOverride": {
       "isHidden": "true",
       "longName": "target-framework-override",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -19,7 +19,53 @@
   },
   "sourceName": "Company.WebApplication1",
   "preferNameDirectory": true,
-  "symbols":{
+  "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "RuntimeFrameworkVersion": {
       "type": "parameter",
       "replaces": "2.1.0-preview2-25624-02",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -44,17 +44,14 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "HttpPort": {
+      "isHidden": true
+    },
     "HttpsPort": {
       "isHidden": true
     },
-    "KestrelPort": {
-      "isHidden": true
-    },
-    "IISExpressPort": {
-      "isHidden": true
-    },
-    "IncludeLaunchSettings": {
-      "longName": "use-launch-settings",
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
       "shortName": ""
     },
     "UserSecretsId": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -33,7 +33,7 @@
           ]
         },
         {
-          "condition": "(!IncludeLaunchSettings && !WindowsAuth)",
+          "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
           ]
@@ -138,16 +138,34 @@
       "defaultValue": "aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502",
       "description": "The ID to use for secrets (use with OrgReadAccess or Individual auth)."
     },
-    "IncludeLaunchSettings": {
+    "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Whether to include launchSettings.json in the generated template."
+      "description": "Whether to exclude launchSettings.json in the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
     },
     "HttpsPort": {
       "type": "parameter",
       "datatype": "integer",
-      "description": "Port number to use to configure SSL in launchSettings.json."
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
     },
     "HttpsPortGenerated": {
       "type": "generated",
@@ -164,43 +182,7 @@
         "sourceVariableName": "HttpsPort",
         "fallbackVariableName": "HttpsPortGenerated"
       },
-      "replaces": "43434"
-    },
-    "KestrelPort": {
-      "type": "parameter",
-      "datatype": "integer",
-      "description": "Port number to use to configure Kestrel in launchSettings.json."
-    },
-    "KestrelPortGenerated": {
-      "type": "generated",
-      "generator": "port"
-    },
-    "KestrelPortReplacer": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "KestrelPort",
-        "fallbackVariableName": "KestrelPortGenerated"
-      },
-      "replaces": "5000"
-    },
-    "IISExpressPort": {
-      "type": "parameter",
-      "datatype": "integer",
-      "description": "Port number to use to configure IIS Express in launchSettings.json."
-    },
-    "IISExpressPortGenerated": {
-      "type": "generated",
-      "generator": "port"
-    },
-    "IISExpressPortReplacer": {
-      "type": "generated",
-      "generator": "coalesce",
-      "parameters": {
-        "sourceVariableName": "IISExpressPort",
-        "fallbackVariableName": "IISExpressPortGenerated"
-      },
-      "replaces": "55556"
+      "replaces": "44300"
     },
     "OrganizationalAuth": {
       "type": "computed",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/vs-2017.3.host.json
@@ -40,19 +40,11 @@
   ],
   "ports": [
     {
-      "name": "IISExpressPort",
-      "useHttps": false
-    },
-    {
-      "name": "KestrelPort",
-      "useHttps": false
-    },
-    {
       "name": "HttpsPort",
       "useHttps": true
     }
   ],
+  "excludeLaunchSettings": false,
   "azureReplyUrlPortName": "HttpsPort",
-  "includeLaunchSettings": true,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/Startup.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 #if (OrganizationalAuth || IndividualB2CAuth)
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -49,7 +50,12 @@ namespace Company.WebApplication1
             {
                 app.UseDeveloperExceptionPage();
             }
+            else
+            {
+                app.UseHsts();
+            }
 
+            app.UseHttpsRedirection();
 #if (OrganizationalAuth || IndividualAuth)
             app.UseAuthentication();
 #endif

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
@@ -1,6 +1,16 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
+    },
     "TargetFrameworkOverride": {
       "isHidden": "true",
       "longName": "target-framework-override",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -19,6 +19,52 @@
   "sourceName": "Company.WebApplication1",
   "preferNameDirectory": true,
   "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "RuntimeFrameworkVersion": {
       "type": "parameter",
       "replaces": "2.1.0-preview2-25624-02",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Microsoft.DotNet.Web.Spa.ProjectTemplates.csproj
@@ -14,6 +14,7 @@
     <GeneratedContentProperties>
       MicrosoftAspNetCoreAllPackageVersion=$(MicrosoftAspNetCoreAllPackageVersion);
       MicrosoftAspNetCorePackageVersion=$(MicrosoftAspNetCorePackageVersion);
+      MicrosoftAspNetCoreHttpsPolicyPackageVersion=$(MicrosoftAspNetCoreHttpsPolicyPackageVersion);
       MicrosoftAspNetCoreMvcPackageVersion=$(MicrosoftAspNetCoreMvcPackageVersion);
       MicrosoftAspNetCoreSpaServicesPackageVersion=$(MicrosoftAspNetCoreSpaServicesPackageVersion);
       MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion=$(MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion);

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,16 @@
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""
+    },
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
     }
   }
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
@@ -22,10 +22,64 @@
       "target": "./",
       "exclude": [
         ".template.config/**"
+      ],
+      "modifiers": [
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
+        }
       ]
     }
   ],
   "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "TargetFrameworkOverride": {
       "type": "parameter",
       "description": "Overrides the target framework",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/vs-2017.3.host.json
@@ -16,5 +16,12 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "ports": [
+    {
+      "name": "HttpsPort",
+      "useHttps": true
+    }
+  ],
+  "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/Startup.cs
@@ -37,8 +37,10 @@ namespace AngularSpa
             else
             {
                 app.UseExceptionHandler("/Home/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
 

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,16 @@
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""
+    },
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
     }
   }
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
@@ -22,10 +22,64 @@
       "target": "./",
       "exclude": [
         ".template.config/**"
+      ],
+      "modifiers": [
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
+        }
       ]
     }
   ],
   "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "TargetFrameworkOverride": {
       "type": "parameter",
       "description": "Overrides the target framework",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/vs-2017.3.host.json
@@ -16,5 +16,12 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "ports": [
+    {
+      "name": "HttpsPort",
+      "useHttps": true
+    }
+  ],
+  "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/Startup.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,8 +38,10 @@ namespace ReactSpa
             else
             {
                 app.UseExceptionHandler("/Home/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
 

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/dotnetcli.host.json
@@ -9,6 +9,16 @@
     "Framework": {
       "longName": "framework"
     },
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
+    },
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
@@ -22,10 +22,64 @@
       "target": "./",
       "exclude": [
         ".template.config/**"
+      ],
+      "modifiers": [
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
+        }
       ]
     }
   ],
   "symbols": {
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "HttpPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTP endpoint in launchSettings.json."
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPort",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json."
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    },
     "TargetFrameworkOverride": {
       "type": "parameter",
       "description": "Overrides the target framework",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/vs-2017.3.host.json
@@ -16,5 +16,12 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "ports": [
+    {
+      "name": "HttpsPort",
+      "useHttps": true
+    }
+  ],
+  "excludeLaunchSettings": false,
   "minFullFrameworkVersion": "4.6.1"
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Startup.cs
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/Startup.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,8 +38,10 @@ namespace ReactReduxSpa
             else
             {
                 app.UseExceptionHandler("/Home/Error");
+                app.UseHsts();
             }
 
+            app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
 

--- a/test/Templates.Test/Helpers/TemplateTestBase.cs
+++ b/test/Templates.Test/Helpers/TemplateTestBase.cs
@@ -17,6 +17,7 @@ namespace Templates.Test
         private static object DotNetNewLock = new object();
 
         protected string ProjectName { get; set; }
+        protected string ProjectGuid { get; set; }
         protected string TemplateOutputDir { get; private set; }
         protected ITestOutputHelper Output { get; private set; }
 
@@ -25,7 +26,8 @@ namespace Templates.Test
             TemplatePackageInstaller.EnsureTemplatePackagesWereReinstalled(output);
 
             Output = output;
-            ProjectName = Guid.NewGuid().ToString().Replace("-", "");
+            ProjectGuid = Guid.NewGuid().ToString("N");
+            ProjectName = $"AspNet.Template.{ProjectGuid}";
 
             var assemblyPath = GetType().GetTypeInfo().Assembly.CodeBase;
             var assemblyUri = new Uri(assemblyPath, UriKind.Absolute);

--- a/test/Templates.Test/Helpers/WebDriverFactory.cs
+++ b/test/Templates.Test/Helpers/WebDriverFactory.cs
@@ -1,17 +1,24 @@
-﻿using OpenQA.Selenium;
-using OpenQA.Selenium.Edge;
-using OpenQA.Selenium.Firefox;
-using System;
+﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Edge;
+using OpenQA.Selenium.Firefox;
 
 namespace Templates.Test.Helpers
 {
     public static class WebDriverFactory
     {
+        // Maximum time any action performed by WebDriver will wait before failing.
+        // Any action will have to be completed in at most 10 seconds.
+        // Providing a smaller value won't improve the speed of the tests in any
+        // significant way and will make them more prone to fail on slower drivers.
+        private const int DefaultMaxWaitTimeInSeconds = 10;
+
         public static bool HostSupportsBrowserAutomation
-            => IsAppVeyor || OSSupportsEdge();
+            => string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ASPNETCORE_BROWSER_AUTOMATION_DISABLED")) &&
+               (IsAppVeyor || OSSupportsEdge());
 
         private static bool IsAppVeyor
             => Environment.GetEnvironmentVariables().Contains("APPVEYOR");
@@ -21,16 +28,24 @@ namespace Templates.Test.Helpers
             // Where possible, it's preferable to use Edge because it's
             // far faster to automate than Chrome/Firefox. But on AppVeyor
             // only Firefox is available.
-            var result = IsAppVeyor ? CreateFirefoxDriver() : CreateEdgeDriver();
-            result.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1);
+            var result = (IsAppVeyor || UseFirefox()) ? CreateFirefoxDriver() : CreateEdgeDriver();
+            result.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(DefaultMaxWaitTimeInSeconds);
             return result;
+
+            bool UseFirefox() => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("ASPNETCORE_BROWSER_AUTOMATION_FIREFOX"));
         }
 
         private static IWebDriver CreateEdgeDriver()
             => new EdgeDriver(EdgeDriverService.CreateDefaultService(BinDir));
 
         private static IWebDriver CreateFirefoxDriver()
-            => new FirefoxDriver(FirefoxDriverService.CreateDefaultService(BinDir));
+            => new FirefoxDriver(
+                FirefoxDriverService.CreateDefaultService(BinDir),
+                new FirefoxOptions()
+                {
+                    AcceptInsecureCertificates = true
+                },
+                TimeSpan.FromSeconds(DefaultMaxWaitTimeInSeconds));
 
         private static string BinDir
             => Path.GetDirectoryName(typeof(WebDriverFactory).Assembly.Location);
@@ -45,7 +60,7 @@ namespace Templates.Test.Helpers
         private static bool OSSupportsEdge()
         {
             var windowsVersion = GetWindowsVersion();
-            return (windowsVersion >= 10 && windowsVersion < 2000)
+            return (windowsVersion >= DefaultMaxWaitTimeInSeconds && windowsVersion < 2000)
                 || (windowsVersion >= 2016);
         }
     }

--- a/test/Templates.Test/MvcTemplateTest.cs
+++ b/test/Templates.Test/MvcTemplateTest.cs
@@ -24,7 +24,7 @@ namespace Templates.Test
         [InlineData(null)]
         [InlineData("F#")]
         public void MvcTemplate_NoAuth_Works_NetCore(string languageOverride)
-            => MvcTemplate_NoAuthImpl(null, languageOverride);
+            => MvcTemplate_NoAuthImpl(null, languageOverride: languageOverride);
 
         private void MvcTemplate_NoAuthImpl(string targetFrameworkOverride, string languageOverride)
         {

--- a/test/Templates.Test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/test/Templates.Test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -62,7 +62,7 @@ namespace Templates.Test.SpaTemplateTest
         private void TestBasicNavigation(IWebDriver browser)
         {
             // <title> element gets project ID injected into it during template execution
-            Assert.Contains(ProjectName, browser.Title);
+            Assert.Contains(ProjectGuid, browser.Title);
 
             // Initially displays the home page
             Assert.Equal("Hello, world!", browser.GetText("h1"));

--- a/test/Templates.Test/Templates.Test.csproj
+++ b/test/Templates.Test/Templates.Test.csproj
@@ -2,10 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Certificates.Generation.Sources" Version="$(MicrosoftAspNetCoreCertificatesGenerationSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Process.Sources" Version="$(MicrosoftExtensionsProcessSourcesPackageVersion)" PrivateAssets="All" />


### PR DESCRIPTION
* Adds launchSettings.json to all of our templates.
* Provides an alternative flag to exclude it.
* Adds HTTPS support in launchSettings.json.
* Improves some infrastructure aspects.
    * Prefix all our test projects with AspNet.Template to allow easy
      killing of orphaned processes.
    * Setup an HTTPS certificate automatically for use with tests in the
      same way our tooling does it on customers machines.
    * Switch from OS selected ports to randomly selected ports. This is
      required as we need to know the port to use for HTTPS.
    * Allow disabling browser automation through an environment variable.
    * Setup Firefox and Edge to allow untrusted certificates when using
      Selenium.