### PR TITLE
Encode ForgotPassword email link

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Areas/Identity/Controllers/AccountController.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Areas/Identity/Controllers/AccountController.cs
@@ -374,7 +374,7 @@ namespace Company.WebApplication1.Identity.Controllers
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
                 var callbackUrl = Url.ResetPasswordCallbackLink(user.Id, code, Request.Scheme);
                 await _emailSender.SendEmailAsync(model.Email, "Reset Password",
-                   $"Please reset your password by clicking here: <a href='{callbackUrl}'>link</a>");
+                   $"Please reset your password by clicking here: <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>link</a>");
                 return RedirectToAction(nameof(ForgotPasswordConfirmation));
             }
 

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Areas/Identity/Controllers/AccountController.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Areas/Identity/Controllers/AccountController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;


### PR DESCRIPTION
See comment https://github.com/aspnet/templating/issues/79#issuecomment-348628023

It works without encoding but it is recommended that the html links be encoded if it has special characters like &