### PR TITLE
[WIP] Update F# templates to use HTTPS and other small C# parity

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
@@ -15,6 +15,9 @@
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
+    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="${MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion}" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
@@ -19,6 +19,7 @@
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,16 @@
       "longName": "no-restore",
       "shortName": ""
     },
+    "HttpPort": {
+      "isHidden": true
+    },
+    "HttpsPort": {
+      "isHidden": true
+    },
+    "ExcludeLaunchSettings": {
+      "longName": "exclude-launch-settings",
+      "shortName": ""
+    },
     "RuntimeFrameworkVersion": {
       "longName": "runtime-framework-version",
       "shortName": "fv",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -26,6 +26,12 @@
           "exclude": [
             "app.config"
           ]
+        },
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
         }
       ]
     }
@@ -36,6 +42,12 @@
       "replaces": "2.1.0-preview2-25624-02",
       "datatype": "string",
       "defaultValue": "2.1.0-preview2-25624-02"
+    },
+    "ExcludeLaunchSettings": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to exclude launchSettings.json from the generated template."
     },
     "TargetFrameworkOverride": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/Properties/launchSettings.json
@@ -1,0 +1,28 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:8080",
+      "sslPort": 44300
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTPS_PORT": "44300"
+      }
+    },
+    "Company.WebApplication1": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "https://localhost:44300;http://localhost:8080"
+      }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/Startup.fs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/Startup.fs
@@ -1,6 +1,5 @@
 namespace Company.WebApplication1
 
-open System
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.Http
@@ -8,12 +7,14 @@ open Microsoft.Extensions.DependencyInjection
 
 type Startup() =
 
+    // This method gets called by the runtime. Use this method to add services to the container.
+    // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
     member this.ConfigureServices(services: IServiceCollection) =
         ()
 
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment) =
-        if env.IsDevelopment() then app.UseDeveloperExceptionPage() |> ignore
+        if env.IsDevelopment() then 
+            app.UseDeveloperExceptionPage() |> ignore
 
-        app.Run(fun context -> context.Response.WriteAsync("Hello World!"))
-
-        ()
+        app.Run(fun context -> context.Response.WriteAsync("Hello World!")) |> ignore

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -1,5 +1,5 @@
 {
-"$schema": "http://json.schemastore.org/dotnetcli.host",
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
     "HttpPort": {
       "isHidden": true

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -27,16 +27,34 @@
           "exclude": [
             "app.config"
           ]
+        },
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
         }
       ]
     }
   ],
   "symbols": {
+    "RuntimeFrameworkVersion": {
+      "type": "parameter",
+      "replaces": "2.1.0-preview2-25624-02",
+      "datatype": "string",
+      "defaultValue": "2.1.0-preview2-25624-02"
+    },
     "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Whether to exclude launchSettings.json from the generated template."
+    },
+    "UseBrowserLink": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to include BrowserLink in the project"
     },
     "HttpPort": {
       "type": "parameter",
@@ -77,12 +95,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
     },
     "TargetFrameworkOverride": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/Startup.fs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/Startup.fs
@@ -1,14 +1,10 @@
 ﻿namespace Company.WebApplication1
 
-open System
-open System.Collections.Generic
-open System.Linq
-open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.HttpsPolicy
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
-
 
 type Startup private () =
     new (configuration: IConfiguration) as this =
@@ -27,7 +23,9 @@ type Startup private () =
             app.UseDeveloperExceptionPage() |> ignore
         else
             app.UseExceptionHandler("/Home/Error") |> ignore
+            app.UseHsts() |> ignore
 
+        app.UseHttpsRedirection() |> ignore
         app.UseStaticFiles() |> ignore
 
         app.UseMvc(fun routes ->

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -26,6 +26,12 @@
           "exclude": [
             "app.config"
           ]
+        },
+        {
+          "condition": "(ExcludeLaunchSettings)",
+          "exclude": [
+            "Properties/launchSettings.json"
+          ]
         }
       ]
     }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/Startup.fs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/Startup.fs
@@ -1,14 +1,10 @@
 namespace Company.WebApplication1
 
-open System
-open System.Collections.Generic
-open System.Linq
-open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.HttpsPolicy
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
-
 
 type Startup private () =
     new (configuration: IConfiguration) as this =
@@ -22,6 +18,12 @@ type Startup private () =
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
     member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment) =
+        if (env.IsDevelopment()) then
+            app.UseDeveloperExceptionPage() |> ignore
+        else
+            app.UseHsts() |> ignore
+
+        app.UseHttpsRedirection() |> ignore
         app.UseMvc() |> ignore
 
     member val Configuration : IConfiguration = null with get, set


### PR DESCRIPTION
Addresses #185

WIP, as I don't quite know what I'm doing here w.r.t the files which _aren't_ F# or project files.  A few points:

* I snagged the `content` folder of the build artifacts and extracted them elsewhere on my machine.  They don't build due to an imports property.  Is that expected?

```
C:\Users\Phillip Carter\Desktop\test\content\Directory.Build.props(2,5): error MSB4019:

The imported project "C:\Users\Phillip Carter\build\sources.props" was not found.

Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.

[C:\Users\Phillip Carter\Desktop\test\content\WebApi-FSharp\Company.WebApplication1.fsproj]
```

* I ran `build` on my machine and there were some errors, but they didn't seem related to these changes.  This is the relevant part of that log:

```
       Date: 2017-12-11T22:23:26.895Z

 info: Microsoft.AspNetCore.SpaServices[0]
       Hash: 0d8c87b1575e19d229ac
 Time: 6373ms
 chunk {inline} inline.bundle.js (inline) 5.79 kB [entry] [rendered]
 chunk {main} main.bundle.js (main) 69.5 kB [initial] [rendered]
 chunk {polyfills} polyfills.bundle.js (polyfills) 574 kB [initial] [rendered]
 chunk {styles} styles.bundle.css (styles) 116 kB [initial] [rendered]
 chunk {vendor} vendor.bundle.js (vendor) 9.1 MB [initial] [rendered]


 info: Microsoft.AspNetCore.SpaServices[0]
       webpack: Compiled successfully.

 info: Microsoft.AspNetCore.Hosting.Internal.WebHost[2]
       Request finished in 9667.0458ms 200 text/html; charset=UTF-8
 Opening browser at http://localhost:5543/...
 info: Microsoft.AspNetCore.Hosting.Internal.WebHost[1]
       Request starting HTTP/1.1 GET http://localhost:5543/
 info: Microsoft.AspNetCore.Rewrite.RewriteMiddleware[8]
       Request redirected to HTTPS
 info: Microsoft.AspNetCore.Hosting.Internal.WebHost[2]
       Request finished in 0.0666ms 302
 info: HttpsConnectionAdapter[1]
       Failed to authenticate HTTPS connection.
 System.IO.IOException: Authentication failed because the remote party has closed the transport stream.
    at System.Net.Security.SslState.StartReadFrame(Byte[] buffer, Int32 readBytes, AsyncProtocolRequest asyncRequest)
    at System.Net.Security.SslState.PartialFrameCallback(AsyncProtocolRequest asyncRequest)
 --- End of stack trace from previous location where exception was thrown ---
    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    at System.Net.Security.SslState.InternalEndProcessAuthentication(LazyAsyncResult lazyResult)
    at System.Net.Security.SslState.EndProcessAuthentication(IAsyncResult result)
    at System.Net.Security.SslStream.EndAuthenticateAsServer(IAsyncResult asyncResult)
    at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
 --- End of stack trace from previous location where exception was thrown ---
    at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
    at Microsoft.AspNetCore.Server.Kestrel.Https.Internal.HttpsConnectionAdapter.<InnerOnConnectionAsync>d__10.MoveNext()
 Failed to delete directory C:\repos\templating\test\Templates.Test\bin\Debug\netcoreapp2.0\TestTemplates\AspNet.Template.cce3371b9f7940d8913f02a250dbcb57 because of error Access to the path 'AspNet.Template.cce3371b9f7940d8913f02a250dbcb57.dll' is denied.. Will try again 9 more time(s).


Total tests: 21. Passed: 14. Failed: 7. Skipped: 0.
Test Run Failed.
Test execution time: 4.4716 Minutes
C:\Users\Phillip Carter\.dotnet\buildtools\korebuild\2.1.0-preview1-15576\modules\vstest\module.targets(101,5): error : Test group UnitTests/netcoreapp2.0 failed [C:\Users\Phillip Carter\.dotnet\buildtools\korebuild\2.1.0-preview1-15576\KoreBuild.proj]

Build FAILED.

C:\Users\Phillip Carter\.dotnet\buildtools\korebuild\2.1.0-preview1-15576\modules\vstest\module.targets(101,5): error : Test group UnitTests/netcoreapp2.0 failed [C:\Users\Phillip Carter\.dotnet\buildtools\korebuild\2.1.0-preview1-15576\KoreBuild.proj]
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:04:36.60
dotnet.exe failed with exit code: 1
At C:\Users\Phillip Carter\.dotnet\buildtools\korebuild\2.1.0-preview1-15576\scripts\common.psm1:11 char:9
+         throw "$cmdName failed with exit code: $exitCode"
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (dotnet.exe failed with exit code: 1:String) [], RuntimeException
    + FullyQualifiedErrorId : dotnet.exe failed with exit code: 1
```

Running build on my machine seemed to fail in the same way before I made any changes.