### PR TITLE
Prevent users from removing their last login if they don't have a password

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Areas/Identity/Controllers/ManageController.cs
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/Areas/Identity/Controllers/ManageController.cs
@@ -295,6 +295,11 @@ namespace Company.WebApplication1.Identity.Controllers
             {
                 throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
             }
+            
+            if (!await _userManager.HasPasswordAsync(user) && (await _userManager.GetLoginsAsync(user)).Count <= 1)
+            {
+                throw new ApplicationException($"User with ID '{user.Id}' attempted removing their last login when they don't have a password.");
+            }
 
             var result = await _userManager.RemoveLoginAsync(user, model.LoginProvider, model.ProviderKey);
             if (!result.Succeeded)


### PR DESCRIPTION
While this is checked for in `GET /ExternalLogins` (by not showing the remove button), this is not confirmed in `POST /RemoveLogin`. This means a malicious user without a password can manually send a POST request to `/RemoveLogin` containing the details of their last login! This would result in having a password-less user in the database with no external logins.