### PR TITLE
Remove DotNetCliToolReference to dotnet-user-secrets

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -28,7 +28,6 @@
     <MicrosoftEntityFrameworkCoreToolsPackageVersion>2.1.0-preview1-27928</MicrosoftEntityFrameworkCoreToolsPackageVersion>
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.1.0-preview1-27928</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsProcessSourcesPackageVersion>2.1.0-preview1-27928</MicrosoftExtensionsProcessSourcesPackageVersion>
-    <MicrosoftExtensionsSecretManagerToolsPackageVersion>2.1.0-preview1-27928</MicrosoftExtensionsSecretManagerToolsPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.0-preview1-26016-05</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -29,7 +29,6 @@
       MicrosoftEntityFrameworkCoreSqlServerPackageVersion=$(MicrosoftEntityFrameworkCoreSqlServerPackageVersion);
       MicrosoftEntityFrameworkCoreToolsDotNetPackageVersion=$(MicrosoftEntityFrameworkCoreToolsDotNetPackageVersion);
       MicrosoftEntityFrameworkCoreToolsPackageVersion=$(MicrosoftEntityFrameworkCoreToolsPackageVersion);
-      MicrosoftExtensionsSecretManagerToolsPackageVersion=$(MicrosoftExtensionsSecretManagerToolsPackageVersion);
       MicrosoftVisualStudioWebBrowserLinkPackageVersion=$(MicrosoftVisualStudioWebBrowserLinkPackageVersion);
       MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion=$(MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion);
       MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion=$(MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion);

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -9,17 +9,17 @@
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>
   </PropertyGroup>
-  
+
   <ItemGroup Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True' ">
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
     <PackageReference Include="Microsoft.AspNetCore.All" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsPackageVersion}" PrivateAssets="All" Condition="'$(IndividualAuth)' == 'True'" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}" PrivateAssets="All" Condition="'$(IndividualAuth)' == 'True'" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}" Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
@@ -37,11 +37,10 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="${MicrosoftVisualStudioWebBrowserLinkPackageVersion}" Condition="'$(UseBrowserLink)' == 'True'" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}" PrivateAssets="All" Condition="'$(IndividualAuth)' == 'True'" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(NoTools)' != 'True'">
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="${MicrosoftEntityFrameworkCoreToolsDotNetPackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="${MicrosoftExtensionsSecretManagerToolsPackageVersion}" Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -41,7 +41,6 @@
 
   <ItemGroup Condition="'$(NoTools)' != 'True'">
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="${MicrosoftEntityFrameworkCoreToolsDotNetPackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="${MicrosoftExtensionsSecretManagerToolsPackageVersion}" Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="${MicrosoftExtensionsSecretManagerToolsPackageVersion}" Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}" />
   </ItemGroup>
 

--- a/test/Templates.Test/MvcTemplateTest.cs
+++ b/test/Templates.Test/MvcTemplateTest.cs
@@ -76,7 +76,6 @@ namespace Templates.Test
             Assert.Contains("Microsoft.EntityFrameworkCore.Tools", projectFileContents);
             Assert.Contains("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
             Assert.Contains("Microsoft.EntityFrameworkCore.Tools.DotNet", projectFileContents);
-            Assert.Contains("Microsoft.Extensions.SecretManager.Tools", projectFileContents);
 
             foreach (var publish in new[] { false, true })
             {

--- a/test/Templates.Test/RazorPagesTemplateTest.cs
+++ b/test/Templates.Test/RazorPagesTemplateTest.cs
@@ -68,7 +68,6 @@ namespace Templates.Test
             Assert.Contains("Microsoft.EntityFrameworkCore.Tools", projectFileContents);
             Assert.Contains("Microsoft.VisualStudio.Web.CodeGeneration.Design", projectFileContents);
             Assert.Contains("Microsoft.EntityFrameworkCore.Tools.DotNet", projectFileContents);
-            Assert.Contains("Microsoft.Extensions.SecretManager.Tools", projectFileContents);
 
             foreach (var publish in new[] { false, true })
             {


### PR DESCRIPTION
React to aspnet/DotNetTools#370. This package no longer supports being installed via DotNetCliToolReference. Instead, this should be installed as a global tool via `dotnet install tool dotnet-user-secrets`

cref https://github.com/aspnet/specs/issues/107