### PR TITLE
Remove max-width from site.css for F# Starter Web template

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -10,13 +10,6 @@
     padding-right: 15px;
 }
 
-/* Set widths on the form inputs since otherwise they're 100% wide */
-input,
-select,
-textarea {
-    max-width: 280px;
-}
-
 /* Carousel */
 .carousel-caption p {
     font-size: 20px;


### PR DESCRIPTION
Addresses #101 

The only instance found apart from media queries and bootstrap.css 