### PR TITLE
Added support for query string parameters in Knockout-CSharp template.

### DIFF
--- a/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/ClientApp/router.ts
+++ b/src/Microsoft.AspNetCore.SpaTemplates/content/Knockout-CSharp/ClientApp/router.ts
@@ -28,7 +28,7 @@ export class Router {
         });
 
         // Make history.js watch for navigation and notify Crossroads
-        this.disposeHistory = history.listen(location => crossroads.parse(location.pathname));
+        this.disposeHistory = history.listen(location => crossroads.parse(location.pathname + document.location.search));
         this.clickEventListener = evt => {
             let target: any = evt.currentTarget;
             if (target && target.tagName === 'A') {
@@ -43,7 +43,7 @@ export class Router {
         $(document).on('click', 'a', this.clickEventListener);
 
         // Initialize Crossroads with starting location
-        crossroads.parse(history.location.pathname);
+        crossroads.parse(history.location.pathname + document.location.search);
     }
 
     public link(url: string): string {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Updated the initial route for Crossroads so that it includes the query string portion of the URL.
 - Updated the handler for browser history changes so that it includes the query string portion of the URL.  

Addresses #215

Information:

I attempted to register a route that had a query string parameter but crossroads wasn't picking it up.  Here is an example route.  
```
{ url: 'linkaccount{?query}', params: { page: 'streaming-services' } },
```
The problem was that the query string portion of the url was not included when invoking `crossroads.parse()`.  By including `document.location.search` in the string being passed to `crossroads.parse()`, this issue is resolved.  Followed the History.js example from the Crossroads documentation.  https://github.com/millermedeiros/crossroads.js/wiki/Examples#using-with-historyjs