### PR TITLE
Add firewall exclusions for test executables

### DIFF
--- a/test/Templates.Test/Helpers/AddFirewallExclusion.cs
+++ b/test/Templates.Test/Helpers/AddFirewallExclusion.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Templates.Test.Helpers
+{
+    internal class AddFirewallExclusion : IDisposable
+    {
+        private bool _disposedValue = false;
+        private readonly string _exclusionPath;
+
+        public static IDisposable Create(string exclusionPath)
+        {
+            return new AddFirewallExclusion(exclusionPath);
+        }
+
+        private AddFirewallExclusion(string exclusionPath)
+        {
+            if (!File.Exists(exclusionPath))
+            {
+                throw new FileNotFoundException();
+            }
+
+            _exclusionPath = exclusionPath;
+            var startInfo = new ProcessStartInfo
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true,
+                FileName = "cmd.exe",
+                Arguments = $"/c netsh advfirewall firewall add rule name=\"Allow {exclusionPath}\" dir=in action=allow program=\"{exclusionPath}\"",
+                UseShellExecute = false,
+                Verb = "runas",
+                WindowStyle = ProcessWindowStyle.Hidden,
+            };
+
+            Process.Start(startInfo);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    var startInfo = new ProcessStartInfo
+                    {
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        CreateNoWindow = true,
+                        FileName = "cmd.exe",
+                        Arguments = $"/c netsh advfirewall firewall delete rule name=\"Allow {_exclusionPath}\"",
+                        UseShellExecute = false,
+                        Verb = "runas",
+                        WindowStyle = ProcessWindowStyle.Hidden,
+                    };
+
+                    Process.Start(startInfo);
+                }
+
+                _disposedValue = true;
+            }
+        }
+    }
+}

--- a/test/Templates.Test/Helpers/AddFirewallExclusion.cs
+++ b/test/Templates.Test/Helpers/AddFirewallExclusion.cs
@@ -9,16 +9,11 @@ namespace Templates.Test.Helpers
         private bool _disposedValue = false;
         private readonly string _exclusionPath;
 
-        public static IDisposable Create(string exclusionPath)
-        {
-            return new AddFirewallExclusion(exclusionPath);
-        }
-
-        private AddFirewallExclusion(string exclusionPath)
+        public AddFirewallExclusion(string exclusionPath)
         {
             if (!File.Exists(exclusionPath))
             {
-                throw new FileNotFoundException();
+                throw new FileNotFoundException($"File {exclusionPath} was not found.");
             }
 
             _exclusionPath = exclusionPath;

--- a/test/Templates.Test/Helpers/AspNetProcess.cs
+++ b/test/Templates.Test/Helpers/AspNetProcess.cs
@@ -74,25 +74,23 @@ namespace Templates.Test.Helpers
             {
                 var dllPath = publish ? $"{projectName}.dll" : $"bin/Debug/{framework}/{projectName}.dll";
                 _process = ProcessEx.Run(output, workingDirectory, DotNetMuxer.MuxerPathOrDefault(), $"exec {dllPath}", envVars: envVars);
-                var listeningUrlString = GetListeningUrlString(output);
-                _listeningUri = new Uri(listeningUrlString, UriKind.Absolute);
+                _listeningUri = GetListeningUri(output);
             }
             else
             {
                 var exeFullPath = publish
                     ? Path.Combine(workingDirectory, $"{projectName}.exe")
                     : Path.Combine(workingDirectory, "bin", "Debug", framework, $"{projectName}.exe");
-                using (AddFirewallExclusion.Create(exeFullPath))
+                using (new AddFirewallExclusion(exeFullPath))
                 {
                     _process = ProcessEx.Run(output, workingDirectory, exeFullPath, envVars: envVars);
-                    var listeningUrlString = GetListeningUrlString(output);
-                    _listeningUri = new Uri(listeningUrlString, UriKind.Absolute);
+                    _listeningUri = GetListeningUri(output);
                 }
             }
 
         }
 
-        private string GetListeningUrlString(ITestOutputHelper output)
+        private Uri GetListeningUri(ITestOutputHelper output)
         {
             // Wait until the app is accepting HTTP requests
             output.WriteLine("Waiting until ASP.NET application is accepting connections...");
@@ -110,7 +108,7 @@ namespace Templates.Test.Helpers
                 listeningUrlString.Substring(listeningUrlString.LastIndexOf(':'));
 
             output.WriteLine("Sending requests to " + listeningUrlString);
-            return listeningUrlString;
+            return new Uri(listeningUrlString, UriKind.Absolute);
         }
 
         public void AssertOk(string requestUrl)


### PR DESCRIPTION
Proposed workaround for the Windows Firewall prompts that appear when running templating tests locally.

It requires running tests in a process running as the Administrator as elevated privileges are required to add firewall exclusions. If not run as an Admin, the prompts will still appear and the tests will not be interrupted otherwise (will not fail because of these changes).


cc @mkArtakMSFT 