### PR TITLE
Remove RuntimeFrameworkVersion from the templates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 ﻿init:
   - git config --global core.autocrlf true
 install:
-   - ps: Install-Product node 8.4.0 x64
+   - ps: Install-Product node 8 x64
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   global:
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     - DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    - TRAVIS_NODE_VERSION: 8.9.3
 addons:
   apt:
     packages:
@@ -13,16 +14,14 @@ mono: none
 os:
   - linux
   - osx
-osx_image: xcode8.2
+osx_image: xcode9.2
 branches:
   only:
-    - master
-    - release
     - dev
-    - /^rel\/.*$/
     - /^release\/.*$/
     - /^(.*\/)?ci-.*$/
 before_install:
+  - nvm install $TRAVIS_NODE_VERSION
   - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
   - ./build.sh

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -36,7 +36,6 @@
     <MicrosoftVisualStudioWebBrowserLinkPackageVersion>2.1.0-preview1-28163</MicrosoftVisualStudioWebBrowserLinkPackageVersion>
     <MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion>2.1.0-preview1-28163</MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion>
     <MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion>2.1.0-preview1-28163</MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion>
-    <NETStandardLibraryPackageVersion>2.0.0</NETStandardLibraryPackageVersion>
     <SeleniumFirefoxWebDriverPackageVersion>0.19.0</SeleniumFirefoxWebDriverPackageVersion>
     <SeleniumSupportPackageVersion>3.7.0</SeleniumSupportPackageVersion>
     <SeleniumWebDriverMicrosoftDriverPackageVersion>16.16299.0</SeleniumWebDriverMicrosoftDriverPackageVersion>

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
-  "channel": "dev"
+  "channel": "dev",
+  "toolsets": {
+    "nodejs": {
+      "required": true,
+      "minVersion": "8.0"
+    }
+  }
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <RuntimeFrameworkVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${NETStandardLibraryPackageVersion}</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <RuntimeFrameworkVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${NETStandardLibraryPackageVersion}</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/Microsoft.DotNet.Web.ProjectTemplates.csproj
@@ -33,8 +33,6 @@
       MicrosoftVisualStudioWebBrowserLinkPackageVersion=$(MicrosoftVisualStudioWebBrowserLinkPackageVersion);
       MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion=$(MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion);
       MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion=$(MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion);
-      MicrosoftNETCoreApp21PackageVersion=$(MicrosoftNETCoreApp21PackageVersion);
-      NETStandardLibraryPackageVersion=$(NETStandardLibraryPackageVersion);
     </GeneratedContentProperties>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <RuntimeFrameworkVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${NETStandardLibraryPackageVersion}</NETStandardImplicitPackageVersion>
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-0ce56475-d1db-490f-8af1-a881ea4fcd2d</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <RuntimeFrameworkVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${NETStandardLibraryPackageVersion}</NETStandardImplicitPackageVersion>
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <RuntimeFrameworkVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${NETStandardLibraryPackageVersion}</NETStandardImplicitPackageVersion>
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <RuntimeFrameworkVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${NETStandardLibraryPackageVersion}</NETStandardImplicitPackageVersion>
-
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <RuntimeFrameworkVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition="'$(Framework)' == 'netcoreapp2.1'">${NETStandardLibraryPackageVersion}</NETStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -22,11 +22,6 @@
     "ExcludeLaunchSettings": {
       "longName": "exclude-launch-settings",
       "shortName": ""
-    },
-    "RuntimeFrameworkVersion": {
-      "longName": "runtime-framework-version",
-      "shortName": "fv",
-      "isHidden": "true"
     }
   },
   "usageExamples": [

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -41,12 +41,6 @@
     }
   ],
   "symbols": {
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
-    },
     "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
@@ -22,11 +22,6 @@
     "ExcludeLaunchSettings": {
       "longName": "exclude-launch-settings",
       "shortName": ""
-    },
-    "RuntimeFrameworkVersion": {
-      "longName": "runtime-framework-version",
-      "shortName": "fv",
-      "isHidden": "true"
     }
   },
   "usageExamples": [

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -37,12 +37,6 @@
     }
   ],
   "symbols": {
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
-    },
     "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
@@ -76,11 +76,6 @@
     "UseBrowserLink": {
       "longName": "use-browserlink",
       "shortName": ""
-    },
-    "RuntimeFrameworkVersion": {
-      "longName": "runtime-framework-version",
-      "shortName": "fv",
-      "isHidden": "true"
     }
   },
   "usageExamples": [

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -89,12 +89,6 @@
     }
   ],
   "symbols": {
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
-    },
     "auth": {
       "type": "parameter",
       "datatype": "choice",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -76,11 +76,6 @@
     "UseBrowserLink": {
       "longName": "use-browserlink",
       "shortName": ""
-    },
-    "RuntimeFrameworkVersion": {
-      "longName": "runtime-framework-version",
-      "shortName": "fv",
-      "isHidden": "true"
     }
   },
   "usageExamples": [

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -84,12 +84,6 @@
     }
   ],
   "symbols": {
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
-    },
     "auth": {
       "type": "parameter",
       "datatype": "choice",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -22,11 +22,6 @@
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""
-    },
-    "RuntimeFrameworkVersion": {
-      "longName": "runtime-framework-version",
-      "shortName": "fv",
-      "isHidden": "true"
     }
   },
   "usageExamples": [

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -38,12 +38,6 @@
     }
   ],
   "symbols": {
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
-    },
     "ExcludeLaunchSettings": {
       "type": "parameter",
       "datatype": "bool",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -56,11 +56,6 @@
     },
     "UserSecretsId": {
       "isHidden": true
-    },
-    "RuntimeFrameworkVersion": {
-      "longName": "runtime-framework-version",
-      "shortName": "fv",
-      "isHidden": "true"
     }
   },
   "usageExamples": [

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -62,12 +62,6 @@
     }
   ],
   "symbols": {
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
-    },
     "auth": {
       "type": "parameter",
       "datatype": "choice",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
@@ -22,11 +22,6 @@
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""
-    },
-    "RuntimeFrameworkVersion": {
-      "longName": "runtime-framework-version",
-      "shortName": "fv",
-      "isHidden": "true"
     }
   },
   "usageExamples": [

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -83,12 +83,6 @@
       },
       "replaces": "44300"
     },
-    "RuntimeFrameworkVersion": {
-      "type": "parameter",
-      "replaces": "2.1.0-preview2-25624-02",
-      "datatype": "string",
-      "defaultValue": "2.1.0-preview2-25624-02"
-    },
     "TargetFrameworkOverride": {
       "type": "parameter",
       "description": "Overrides the target framework",

--- a/test/Templates.Test/Helpers/AspNetProcess.cs
+++ b/test/Templates.Test/Helpers/AspNetProcess.cs
@@ -61,7 +61,7 @@ namespace Templates.Test.Helpers
 
             var envVars = new Dictionary<string, string>
             {
-                { "ASPNETCORE_URLS", $"http://localhost:127.0.0.0:0;https://localhost:127.0.0.0:0" }
+                { "ASPNETCORE_URLS", $"http://127.0.0.1:0;https://127.0.0.1:0" }
             };
 
             if (!publish)


### PR DESCRIPTION
This property is no longer needed because the Microsoft.AspNetCore.All and .App packages set the shared framework version. RuntimeFrameworkVersion is inferred by Microsoft.NET.Sdk.


Note: this targets <kbd>release/2.1</kbd>