### PR TITLE
Add empty TypeScript starter template file. Closes #279

### DIFF
--- a/src/Microsoft.DotNet.Web.Client.ItemTemplates/content/TypeScript/file1.ts
+++ b/src/Microsoft.DotNet.Web.Client.ItemTemplates/content/TypeScript/file1.ts
@@ -1,2 +1,1 @@
-﻿body {
-}
+// Write your TypeScript code.


### PR DESCRIPTION
No content, the header with the same CTA as in `site.js`.

And no BOM, there is no policy to enforce it in the repo.

Thanks!

```diff
--- a/src/Microsoft.DotNet.Web.Client.ItemTemplates/content/TypeScript/file1.ts
+++ b/src/Microsoft.DotNet.Web.Client.ItemTemplates/content/TypeScript/file1.ts
@@ -1,2 +1 @@
-<U+FEFF>body {
-}
+// Write your TypeScript code.
```