### PR TITLE
Revert "Skip flaky tests"

### DIFF
--- a/test/Templates.Test/MvcTemplateTest.cs
+++ b/test/Templates.Test/MvcTemplateTest.cs
@@ -55,13 +55,13 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalFact(Skip="https://github.com/aspnet/templating/issues/286")]
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         public void MvcTemplate_IndividualAuth_Works_NetFramework()
             => MvcTemplate_IndividualAuthImpl("net461");
 
-        [Fact(Skip="https://github.com/aspnet/templating/issues/286")]
+        [Fact]
         public void MvcTemplate_IndividualAuth_Works_NetCore()
             => MvcTemplate_IndividualAuthImpl(null);
 

--- a/test/Templates.Test/RazorPagesTemplateTest.cs
+++ b/test/Templates.Test/RazorPagesTemplateTest.cs
@@ -47,13 +47,13 @@ namespace Templates.Test
             }
         }
 
-        [ConditionalFact(Skip="https://github.com/aspnet/templating/issues/286")]
+        [ConditionalFact]
         [OSSkipCondition(OperatingSystems.Linux)]
         [OSSkipCondition(OperatingSystems.MacOSX)]
         public void RazorPagesTemplate_IndividualAuth_Works_NetFramework()
             => RazorPagesTemplate_IndividualAuthImpl("net461");
 
-        [Fact(Skip="https://github.com/aspnet/templating/issues/286")]
+        [Fact]
         public void RazorPagesTemplate_IndividualAuth_Works_NetCore()
             => RazorPagesTemplate_IndividualAuthImpl(null);
         [Fact]


### PR DESCRIPTION
This reverts commit cff1d46ac903c54a1e14684ed132bcf10d9ddaeb. @javiercn and @jbagga have said that this was a temporary issue which is now resolved.