### PR TITLE
Align class event handler creation with React docs

### DIFF
--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/Counter.js
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/Counter.js
@@ -6,6 +6,7 @@ export class Counter extends Component {
   constructor() {
     super();
     this.state = { currentCount: 0 };
+    this.incrementCounter = this.incrementCounter.bind(this);
   }
 
   incrementCounter() {
@@ -23,7 +24,7 @@ export class Counter extends Component {
 
         <p>Current count: <strong>{this.state.currentCount}</strong></p>
 
-        <button onClick={() => this.incrementCounter()}>Increment</button>
+        <button onClick={this.incrementCounter}>Increment</button>
       </div>
     );
   }


### PR DESCRIPTION
This is small change to align example React app with current advised way of assigning
event handlers that are declared as ES6 class methods:
https://reactjs.org/docs/handling-events.html

Thanks!