### PR TITLE
Add HostFiltering middleware to templates

### DIFF
--- a/Templating.sln
+++ b/Templating.sln
@@ -14,6 +14,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Web.Client
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Web.ProjectTemplates", "src\Microsoft.DotNet.Web.ProjectTemplates\Microsoft.DotNet.Web.ProjectTemplates.csproj", "{260EBA09-DEF5-429C-99BF-90CA1456A576}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{F34CD7D7-1E8F-41FA-AB4D-D86BFD3AC09B}"
+	ProjectSection(SolutionItems) = preProject
+		build\dependencies.props = build\dependencies.props
+		build\repo.props = build\repo.props
+		build\sources.props = build\sources.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/appsettings.json
@@ -35,5 +35,6 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+  "AllowedHosts": [ "*" ]
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/appsettings.json
@@ -35,5 +35,6 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+  "AllowedHosts": [ "*" ]
 }

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/appsettings.json
@@ -22,5 +22,6 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+  "AllowedHosts": [ "*" ]
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/appsettings.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/appsettings.json
@@ -3,5 +3,6 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+  "AllowedHosts": [ "*" ]
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/appsettings.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/appsettings.json
@@ -3,5 +3,6 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+  "AllowedHosts": [ "*" ]
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/appsettings.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/appsettings.json
@@ -3,5 +3,6 @@
     "LogLevel": {
       "Default": "Warning"
     }
-  }
+  },
+  "AllowedHosts": [ "*" ]
 }


### PR DESCRIPTION
This adds the new HostFiltering middleware to every template except Empty and F#. 

~~TODO: Update the dependencies once the 2.1 branch [publishes some](https://dotnet.myget.org/feed/aspnetcore-release/package/nuget/Internal.AspNetCore.Universe.Lineup).~~
~~TODO: Disable the new middleware by default~~
~~TODO: File an issue to port the final version of this to the F# tempalates~~ https://github.com/aspnet/templating/issues/392

@DamianEdwards please look a the code in Startup. It's enabled right now so I can verify the dependencies. The proposal was to disable it by commenting it out. It may be cleaner to disable it by adding this config `"AllowedHosts": [ "*" ]`.

