### PR TITLE
Add update migrations script

### DIFF
--- a/migrations/updateMigrations.cmd
+++ b/migrations/updateMigrations.cmd
@@ -1,0 +1,11 @@
+ECHO on
+echo Make sure to have ran build.cmd once to ensure artifacts have been created.
+rd "Company.WebApplication1" /s /q
+mkdir "Company.WebApplication1"
+dotnet new razor --auth Individual -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.2.1.2.1.0-preview3-t000.nupkg -o Company.WebApplication1
+copy "Company.WebApplication1\Data\Migrations\*" "..\src\Microsoft.DotNet.Web.ProjectTemplates\content\RazorPagesWeb-CSharp\Data\SqlLite"
+rd "Company.WebApplication1" /s /q
+mkdir "Company.WebApplication1"
+dotnet new razor --auth Individual --use-local-db -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.2.1.2.1.0-preview3-t000.nupkg -o Company.WebApplication1
+copy "Company.WebApplication1\Data\Migrations\*" "..\src\Microsoft.DotNet.Web.ProjectTemplates\content\RazorPagesWeb-CSharp\Data\SqlServer"
+rd "Company.WebApplication1" /s /q

--- a/migrations/updateMigrations.cmd
+++ b/migrations/updateMigrations.cmd
@@ -9,3 +9,11 @@ mkdir "Company.WebApplication1"
 dotnet new razor --auth Individual --use-local-db -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.*.nupkg -o Company.WebApplication1
 copy "Company.WebApplication1\Data\Migrations\*" "..\src\Microsoft.DotNet.Web.ProjectTemplates\content\RazorPagesWeb-CSharp\Data\SqlServer"
 rd "Company.WebApplication1" /s /q
+mkdir "Company.WebApplication1"
+dotnet new mvc --auth Individual --use-local-db -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.*.nupkg -o Company.WebApplication1
+copy "Company.WebApplication1\Data\Migrations\*" "..\src\Microsoft.DotNet.Web.ProjectTemplates\content\StarterWeb-CSharp\Data\SqlServer"
+rd "Company.WebApplication1" /s /q
+mkdir "Company.WebApplication1"
+dotnet new mvc --auth Individual -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.*.nupkg -o Company.WebApplication1
+copy "Company.WebApplication1\Data\Migrations\*" "..\src\Microsoft.DotNet.Web.ProjectTemplates\content\StarterWeb-CSharp\Data\SqlLite"
+rd "Company.WebApplication1" /s /q

--- a/migrations/updateMigrations.cmd
+++ b/migrations/updateMigrations.cmd
@@ -2,10 +2,10 @@ ECHO on
 echo Make sure to have ran build.cmd once to ensure artifacts have been created.
 rd "Company.WebApplication1" /s /q
 mkdir "Company.WebApplication1"
-dotnet new razor --auth Individual -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.2.1.2.1.0-preview3-t000.nupkg -o Company.WebApplication1
+dotnet new razor --auth Individual -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.*.nupkg -o Company.WebApplication1
 copy "Company.WebApplication1\Data\Migrations\*" "..\src\Microsoft.DotNet.Web.ProjectTemplates\content\RazorPagesWeb-CSharp\Data\SqlLite"
 rd "Company.WebApplication1" /s /q
 mkdir "Company.WebApplication1"
-dotnet new razor --auth Individual --use-local-db -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.2.1.2.1.0-preview3-t000.nupkg -o Company.WebApplication1
+dotnet new razor --auth Individual --use-local-db -i ..\artifacts\build\Microsoft.DotNet.Web.ProjectTemplates.*.nupkg -o Company.WebApplication1
 copy "Company.WebApplication1\Data\Migrations\*" "..\src\Microsoft.DotNet.Web.ProjectTemplates\content\RazorPagesWeb-CSharp\Data\SqlServer"
 rd "Company.WebApplication1" /s /q

--- a/migrations/updateMigrations.cmd
+++ b/migrations/updateMigrations.cmd
@@ -1,4 +1,3 @@
-ECHO on
 echo Make sure to have ran build.cmd once to ensure artifacts have been created.
 rd "Company.WebApplication1" /s /q
 mkdir "Company.WebApplication1"

--- a/test/Templates.Test/Helpers/TemplateTestBase.cs
+++ b/test/Templates.Test/Helpers/TemplateTestBase.cs
@@ -107,6 +107,7 @@ namespace Templates.Test
             }
         }
 
+        // If this fails, you should generate new migrations via migrations/updateMigrations.cmd
         protected void AssertEmptyMigration(string migration)
         {
             var fullPath = Path.Combine(TemplateOutputDir, "Data/Migrations");


### PR DESCRIPTION
Last part of https://github.com/aspnet/templating/issues/309

Adds a manual migrations/updateMigrations.cmd that runs dotnet new against razor + mvc, and copies over the migrations