### PR TITLE
Add supportedAuthentication for NoAuth in templates which have NoAuth…

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -16,6 +16,13 @@
   "uiFilters": [ "oneaspnet" ],
   "supportsDocker": true,
   "legacyTemplateIdentity": "Microsoft.NetCore.CSharp.EmptyWeb",
+  "supportedAuthentications": [
+    {
+      "auth": "None",
+      "authenticationType": "NoAuth",
+      "allowUnsecured": true
+    }
+  ],
   "ports": [
     {
       "name": "HttpPort",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/vs-2017.3.host.json
@@ -14,6 +14,13 @@
   "icon": "vs-2017.3/Empty.png",
   "learnMoreLink": "https://go.microsoft.com/fwlink/?LinkID=784883",
   "uiFilters": [ "oneaspnet" ],
+  "supportedAuthentications": [
+    {
+      "auth": "None",
+      "authenticationType": "NoAuth",
+      "allowUnsecured": true
+    }
+  ],
   "supportsDocker": true,
   "ports": [
     {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/vs-2017.3.host.json
@@ -16,6 +16,13 @@
   "uiFilters": [ "oneaspnet" ],
   "supportsDocker": true,
   "isApi": true,
+  "supportedAuthentications": [
+    {
+      "auth": "None",
+      "authenticationType": "NoAuth",
+      "allowUnsecured": true
+    }
+  ],
   "ports": [
     {
       "name": "HttpPort",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/vs-2017.3.host.json
@@ -16,6 +16,13 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "supportedAuthentications": [
+    {
+      "auth": "None",
+      "authenticationType": "NoAuth",
+      "allowUnsecured": true
+    }
+  ],
   "ports": [
     {
       "name": "HttpPort",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/vs-2017.3.host.json
@@ -16,6 +16,13 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "supportedAuthentications": [
+    {
+      "auth": "None",
+      "authenticationType": "NoAuth",
+      "allowUnsecured": true
+    }
+  ],
   "ports": [
     {
       "name": "HttpPort",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/vs-2017.3.host.json
@@ -16,6 +16,13 @@
   "uiFilters": [
     "oneaspnet"
   ],
+  "supportedAuthentications": [
+    {
+      "auth": "None",
+      "authenticationType": "NoAuth",
+      "allowUnsecured": true
+    }
+  ],
   "ports": [
     {
       "name": "HttpPort",


### PR DESCRIPTION
… (#443)

* Add supportedAuthentication for NoAuth in templates which have NoAuth

This is to work around an issue in Visual Studio

* Remove spurious ,

* Add supportedAuthentications to F# Web API vs-2017.3.host.json