### PR TITLE
 React to implicit Microsoft.AspNetCore.App reference

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,6 +5,7 @@
   <PropertyGroup Label="Package Versions">
     <DotNetEfPackageVersion>2.1.0-preview3-32233</DotNetEfPackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview3-17018</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreAllPackageVersion>
     <MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion>2.1.0-preview2-32233</MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion>
     <MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion>2.1.0-preview2-32233</MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqlitePackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqlitePackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
   </ItemGroup>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
     <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="${MicrosoftAspNetCoreAllPackageVersion}" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">

--- a/test/GenerateTestProps.targets
+++ b/test/GenerateTestProps.targets
@@ -1,8 +1,24 @@
 <Project>
   <Target Name="GenerateTestProps" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <PropsProperties>RestoreSources=$([MSBuild]::Escape($(RestoreSources)))</PropsProperties>
+      <PropsProperties>$(PropsProperties);RuntimeFrameworkVersion=$(RuntimeFrameworkVersion)</PropsProperties>
+      <PropsProperties>$(PropsProperties);MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion)</PropsProperties>
+
+      <!-- These properties would normally be bundled in the CLI -->
+      <TargetsProperties>BundledAspNetCoreAllTargetFrameworkVersion=$(MicrosoftAspNetCoreAllPackageVersion.Split('.')[0]).$(MicrosoftAspNetCoreAllPackageVersion.Split('.')[1])</TargetsProperties>
+      <TargetsProperties>$(TargetsProperties);BundledAspNetCoreAllPackageVersion=$(MicrosoftAspNetCoreAllPackageVersion)</TargetsProperties>
+      <TargetsProperties>$(TargetsProperties);BundledAspNetCoreAppTargetFrameworkVersion=$(MicrosoftAspNetCoreAppPackageVersion.Split('.')[0]).$(MicrosoftAspNetCoreAppPackageVersion.Split('.')[1])</TargetsProperties>
+      <TargetsProperties>$(TargetsProperties);BundledAspNetCoreAppPackageVersion=$(MicrosoftAspNetCoreAppPackageVersion)</TargetsProperties>
+    </PropertyGroup>
+
     <Sdk_GenerateFileFromTemplate
       TemplateFile="$(MSBuildThisFileDirectory)TemplateTests.props.in"
-      Properties="RestoreSources=$([MSBuild]::Escape($(RestoreSources)));RuntimeFrameworkVersion=$(RuntimeFrameworkVersion);MicrosoftNETSdkRazorPackageVersion=$(MicrosoftNETSdkRazorPackageVersion)"
+      Properties="$(PropsProperties)"
       OutputPath="$(OutputPath)TemplateTests.props" />
+    <Sdk_GenerateFileFromTemplate
+      TemplateFile="$(MSBuildThisFileDirectory)TemplateTests.targets.in"
+      Properties="$(TargetsProperties)"
+      OutputPath="$(OutputPath)TemplateTests.targets" />
   </Target>
 </Project>

--- a/test/TemplateTests.targets.in
+++ b/test/TemplateTests.targets.in
@@ -1,0 +1,144 @@
+<!-- Copied from Web SDK for unit testing here -->
+<!--
+***********************************************************************************************
+Sdk.DefaultItems.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!--
+    Determine the version (including patch) of ASPNET Core to target.
+
+    When targeting ASPNET Core, the TargetFramework is used to specify the major and minor version of the runtime to use.
+    By default, the patch version is inferred. The general logic is that self-contained apps will target the latest patch
+    that the SDK knows about, while framework-dependent apps will target the ".0" patch (and roll forward to the latest
+    patch installed at runtime).
+
+    The TargetLatestAspNetCoreRuntimePatch property can be set to true or false to explicitly opt in or out of the logic
+    to roll forward to the latest patch, regardless of whether the app is self-contained or framework-dependent. The
+    default value of this property is TargetLatestRuntimePatch set by the dotnet SDK.
+
+    The AspNetCoreAppRuntimeFrameworkVersion and AspNetCoreAllRuntimeFrameworkVersion are where the actual versions of the
+    ASPNET Core runtimes to target is stored. They are the versions that are used in the implicit PackageReference to
+    Microsoft.AspNetCore.App and Microsoft.AspNetCore.All. The AspNetCoreAppRuntimeFrameworkVersion and
+    AspNetCoreAllRuntimeFrameworkVersion can also be set explicitly, which will disable all the other logic that
+    automatically selects the version of .NET Core to target.
+
+    The framework version that is written to the runtimeconfig.json file is based on the actual resolved package version
+    of Microsoft.AspNetCore.App or Microsoft.AspNetCore.All. This is to allow floating the verion number (i.e. the user
+    could set the version to "2.0-*".
+
+  -->
+  <Choose>
+    <When Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" >
+
+      <!-- Default patch version of .All Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '${BundledAspNetCoreAllTargetFrameworkVersion}'">${BundledAspNetCoreAllPackageVersion}</DefaultAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAllPatchVersion Condition="'$(DefaultAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Default patch version of .App Framework -->
+      <PropertyGroup Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '${BundledAspNetCoreAppTargetFrameworkVersion}'">${BundledAspNetCoreAppPackageVersion}</DefaultAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the default patch version -->
+        <DefaultAspNetCoreAppPatchVersion Condition="'$(DefaultAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</DefaultAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .All Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">
+        <!-- Placeholder for setting latest patch version using the bundled version from CLI -->
+        <!-- <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreAll2_1)</LatestAspNetCoreAllPatchVersion> -->
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '${BundledAspNetCoreAllTargetFrameworkVersion}'">${BundledAspNetCoreAllPackageVersion}</LatestAspNetCoreAllPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAllPatchVersion Condition="'$(LatestAspNetCoreAllPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAllPatchVersion>
+      </PropertyGroup>
+
+      <!-- Latest patch version of .App Framework -->
+      <PropertyGroup Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">
+        <!-- Placeholder for setting latest patch version using the bundled version from CLI -->
+        <!-- <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '2.1'">$(LatestPatchVersionForAspNetCoreApp2_1)</LatestAspNetCoreAppPatchVersion> -->
+
+        <!-- If targeting the same pre-release that is bundled with the .NET Core SDK, use the bundled package version
+            provided by Microsoft.NETCoreSdk.BundledVersions.props -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(_TargetFrameworkVersionWithoutV)' == '${BundledAspNetCoreAppTargetFrameworkVersion}'">${BundledAspNetCoreAppPackageVersion}</LatestAspNetCoreAppPatchVersion>
+        <!-- If not covered by the previous cases use the target framework version for the latest patch version -->
+        <LatestAspNetCoreAppPatchVersion Condition="'$(LatestAspNetCoreAppPatchVersion)' == ''">$(_TargetFrameworkVersionWithoutV)</LatestAspNetCoreAppPatchVersion>
+      </PropertyGroup>
+
+      <!-- Determine the default values of TargetLatestAspNetCoreRuntimePatch -->
+      <PropertyGroup Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == ''">
+        <TargetLatestAspNetCoreRuntimePatch>false</TargetLatestAspNetCoreRuntimePatch>
+        <TargetLatestAspNetCoreRuntimePatch Condition="'$(SelfContained)' == 'true'">true</TargetLatestAspNetCoreRuntimePatch>
+        <TargetLatestAspNetCoreRuntimePatch Condition="'$(TargetLatestRuntimePatch)' != ''">$(TargetLatestRuntimePatch)</TargetLatestAspNetCoreRuntimePatch>
+      </PropertyGroup>
+
+      <!-- Set the framework version of .All Framework -->
+      <PropertyGroup Condition="'$(AspNetCoreAllRuntimeFrameworkVersion)' == ''">
+        <AspNetCoreAllRuntimeFrameworkVersion>$(DefaultAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+        <AspNetCoreAllRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAllPatchVersion)</AspNetCoreAllRuntimeFrameworkVersion>
+      </PropertyGroup>
+
+      <!-- Set the framework version of .App Framework -->
+      <PropertyGroup Condition="'$(AspNetCoreAppRuntimeFrameworkVersion)' == ''">
+        <AspNetCoreAppRuntimeFrameworkVersion >$(DefaultAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
+        <AspNetCoreAppRuntimeFrameworkVersion Condition="'$(TargetLatestAspNetCoreRuntimePatch)' == 'true'">$(LatestAspNetCoreAppPatchVersion)</AspNetCoreAppRuntimeFrameworkVersion>
+      </PropertyGroup>
+
+      <PropertyGroup>
+        <_AspNetCoreAllPackageName>Microsoft.AspNetCore.All</_AspNetCoreAllPackageName>
+        <_AspNetCoreAppPackageName>Microsoft.AspNetCore.App</_AspNetCoreAppPackageName>
+      </PropertyGroup>
+
+      <ItemGroup>
+        <!-- Determine if ASPNET metapackage references without version numbers exist -->
+        <_AspNetCoreAllReference Include="@(PackageReference->WithMetadataValue('Identity', '$(_AspNetCoreAllPackageName)'))" />
+        <_ExplicitAspNetCoreAllReference Include="@(_AspNetCoreAllReference->HasMetadata('Version'))" />
+        <_AspNetCoreAppReference Include="@(PackageReference->WithMetadataValue('Identity', '$(_AspNetCoreAppPackageName)'))" />
+        <_ExplicitAspNetCoreAppReference Include="@(_AspNetCoreAppReference->HasMetadata('Version'))" />
+
+        <!-- Update implicit ASPNET metapackage references if needed -->
+        <PackageReference
+          Update="$(_AspNetCoreAllPackageName)"
+          Condition="'@(_AspNetCoreAllReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAllReference->Count())' == '0'">
+          <Version>$(AspNetCoreAllRuntimeFrameworkVersion)</Version>
+          <IsImplicitlyDefined>true</IsImplicitlyDefined>
+          <PrivateAssets>All</PrivateAssets>
+          <Publish>true</Publish>
+        </PackageReference>
+        <PackageReference
+          Update="$(_AspNetCoreAppPackageName)"
+          Condition="'@(_AspNetCoreAppReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAppReference->Count())' == '0'">
+          <Version>$(AspNetCoreAppRuntimeFrameworkVersion)</Version>
+          <IsImplicitlyDefined>true</IsImplicitlyDefined>
+          <PrivateAssets>All</PrivateAssets>
+          <Publish>true</Publish>
+        </PackageReference>
+
+        <!-- Update list of implicit platform packages which require version verification -->
+        <ExpectedPlatformPackages
+          Include="$(_AspNetCoreAllPackageName)"
+          ExpectedVersion="$(AspNetCoreAllRuntimeFrameworkVersion)"
+          Condition="'@(_AspNetCoreAllReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAllReference->Count())' == '0'"/>
+        <ExpectedPlatformPackages
+          Include="$(_AspNetCoreAppPackageName)"
+          ExpectedVersion="$(AspNetCoreAppRuntimeFrameworkVersion)"
+          Condition="'@(_AspNetCoreAppReference->Count())' == '1' AND '@(_ExplicitAspNetCoreAppReference->Count())' == '0'"/>
+      </ItemGroup>
+
+    </When>
+  </Choose>
+</Project>

--- a/test/Templates.Test/Helpers/TemplateTestBase.cs
+++ b/test/Templates.Test/Helpers/TemplateTestBase.cs
@@ -42,14 +42,19 @@ namespace Templates.Test
             // Directory.Build.props/targets context
 
             var templatesTestsPropsFilePath = Path.Combine(basePath, "TemplateTests.props");
+            var templatesTestsTargetsFilePath = Path.Combine(basePath, "TemplateTests.targets");
             var directoryBuildPropsContent =
 $@"<Project>
     <Import Project=""{templatesTestsPropsFilePath}"" />
     <Import Project=""Directory.Build.After.props"" Condition=""Exists('Directory.Build.After.props')"" />
 </Project>";
-
             File.WriteAllText(Path.Combine(TemplateOutputDir, "Directory.Build.props"), directoryBuildPropsContent);
-            File.WriteAllText(Path.Combine(TemplateOutputDir, "Directory.Build.targets"), "<Project />");
+
+            var directoryBuildTargetsContent =
+$@"<Project>
+    <Import Project=""{templatesTestsTargetsFilePath}"" />
+</Project>";
+            File.WriteAllText(Path.Combine(TemplateOutputDir, "Directory.Build.targets"), directoryBuildTargetsContent);
         }
 
         protected void InstallTemplatePackages()


### PR DESCRIPTION
Addresses https://github.com/aspnet/Universe/issues/967.

This is the change to remove explicit versions of Microsoft.AspNetCore.App from the default templates. This will go into rc1 so I will send out a shiproom email. Please review but I will not merge until approved.