### PR TITLE
[Design] Use RemoteWebDriver for selenium tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,3 +17,8 @@ environment:
 test: 'off'
 deploy: 'off'
 os: Visual Studio 2017
+before_build:
+  - choco install googlechrome --ignore-checksum
+  - npm install -g selenium-standalone@latest
+  - selenium-standalone install
+  - ps: Start-Process "selenium-standalone" -ArgumentList "start" -PassThru

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ env:
   global:
   - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   - DOTNET_CLI_TELEMETRY_OPTOUT: 1
-  - TRAVIS_NODE_VERSION: 8.9.3
+  - TRAVIS_NODE_VERSION: 8.9.4
 addons:
   apt:
     packages:
     - libunwind8
+  chrome: stable
 mono: none
 os:
 - linux
@@ -25,5 +26,11 @@ before_install:
 - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s
   /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib
   /usr/local/lib/; fi
+install:
+- nvm install $TRAVIS_NODE_VERSION
+- npm install -g selenium-standalone
+- selenium-standalone install
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export TEST_CHROME_BINARY=`which google-chrome-stable`; fi
+- export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
 script:
 - ./build.sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,27 @@ ASP.NET Templates provide project templates which are used in .NET Core for crea
 This project is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [Home](https://github.com/aspnet/home) repo.
 
 ## Building Templates
-- Running build.cmd in this repo requires NPM which can be installed from https://nodejs.org/en/.
+- Running `build.cmd` in this repo requires NPM which can be installed from https://nodejs.org/en/.
 - The ASP.NET localhost development certificate must also be installed and trusted or else you'll get a test error "Certificate error: Navigation blocked".
 - `build.cmd` (or `build /t:package` to avoid tests) will produce NuGet packages for each class of template in the artifacts directory. These can be installed via `dotnet new -i {nugetpackage path}`
 - You also need to get the packages these templates depend on into your package cache or else `dotnet new` restore will fail. The easiest way to get them to run is by letting the build run at least 1 test.
+
+## Building and running all Selenium tests
+Prerequisites:
+- Java 8 or later
+- Chrome/Edge/Firefox
+
+Running `build.cmd` will build and run all tests on Chrome by default. 
+
+It will install and run [selenium-standalone](https://www.npmjs.com/package/selenium-standalone) (requires Java 8 or later) by running the following:
+  - `npm install -g selenium-standalone`
+  - `selenium-standalone install`
+  - `selenium-standalone start`
+
+### To run tests on Microsoft EDGE browser:
+Open a new Powershell window and run the following command:
+$env:ASPNETCORE_BROWSER_AUTOMATION_EDGE="true"
+
+### To run tests on Mozilla FIREFOX browser:
+Open a new Powershell window and run the following command:
+$env:ASPNETCORE_BROWSER_AUTOMATION_FIREFOX="true"

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -44,6 +44,7 @@
     <SeleniumSupportPackageVersion>3.7.0</SeleniumSupportPackageVersion>
     <SeleniumWebDriverMicrosoftDriverPackageVersion>16.16299.0</SeleniumWebDriverMicrosoftDriverPackageVersion>
     <SeleniumWebDriverPackageVersion>3.7.0</SeleniumWebDriverPackageVersion>
+    <SystemManagementPackageVersion>4.5.0-rc1</SystemManagementPackageVersion>
     <SystemSecurityPermissionsPackageVersion>4.5.0-preview3-26423-04</SystemSecurityPermissionsPackageVersion>
     <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>

--- a/test/Templates.Test/EmptyWebTemplateTest.cs
+++ b/test/Templates.Test/EmptyWebTemplateTest.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Testing.xunit;
+using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
+[assembly: AssemblyFixture(typeof(SeleniumServerFixture))]
 namespace Templates.Test
 {
     public class EmptyWebTemplateTest : TemplateTestBase

--- a/test/Templates.Test/Helpers/AssemblyFixtureAttribute.cs
+++ b/test/Templates.Test/Helpers/AssemblyFixtureAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public class AssemblyFixtureAttribute : Attribute
+{
+    public AssemblyFixtureAttribute(Type fixtureType)
+    {
+        FixtureType = fixtureType;
+    }
+
+    public Type FixtureType { get; private set; }
+}

--- a/test/Templates.Test/Helpers/SeleniumServerFixture.cs
+++ b/test/Templates.Test/Helpers/SeleniumServerFixture.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Templates.Test.Helpers
+{
+    public class SeleniumServerFixture : IDisposable
+    {
+        private string _workingDirectory;
+        private Process _serverProcess;
+        private static readonly object _serverLock = new object();
+
+        public SeleniumServerFixture()
+        {
+            _workingDirectory = Directory.GetCurrentDirectory();
+            StartSeleniumStandaloneServer();
+        }
+
+        public void Dispose()
+        {
+            _serverProcess.Kill();
+            _serverProcess.Dispose();
+
+            // Find the java process running selenium-standalone
+            var childProcesses = Process.GetProcessesByName("java");
+            foreach (var childProcess in childProcesses)
+            {
+                childProcess.Kill();
+                childProcess.Dispose();
+            }
+        }
+
+        public void StartSeleniumStandaloneServer()
+        {
+            lock (_serverLock)
+            {
+                RunViaShell(_workingDirectory, "npm install -g selenium standalone");
+            }
+            lock (_serverLock)
+            {
+                RunViaShell(_workingDirectory, "selenium-standalone install");
+            }
+
+            // Starts a java process that runs the selenium server
+            _serverProcess = RunViaShell(_workingDirectory, "selenium-standalone start");
+        }
+
+        private static Process RunViaShell(string workingDirectory, string commandAndArgs)
+        {
+            var (shellExe, argsPrefix) = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? ("cmd", "/c")
+                : ("bash", "-c");
+
+            return Run(workingDirectory, shellExe, $"{argsPrefix} \"{commandAndArgs}\"");
+        }
+
+        private static Process Run(string workingDirectory, string command, string args = null, IDictionary<string, string> envVars = null)
+        {
+            var startInfo = new ProcessStartInfo(command, args)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = workingDirectory
+            };
+
+            return Process.Start(startInfo);
+        }
+    }
+}

--- a/test/Templates.Test/Helpers/SeleniumServerFixture.cs
+++ b/test/Templates.Test/Helpers/SeleniumServerFixture.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Management;
 using System.Runtime.InteropServices;
 
 namespace Templates.Test.Helpers
@@ -24,44 +23,16 @@ namespace Templates.Test.Helpers
 
         public void Dispose()
         {
+            _serverProcess.Kill();
+            _serverProcess.Dispose();
+
             // Find the java process running selenium-standalone
-            foreach (var childProcess in GetChildProcesses(_serverProcess.Id))
+            var childProcesses = Process.GetProcessesByName("java");
+            foreach (var childProcess in childProcesses)
             {
                 childProcess.Kill();
                 childProcess.Dispose();
             }
-
-            _serverProcess.Kill();
-            _serverProcess.Dispose();
-        }
-
-        private static List<Process> GetChildProcesses(int parentProcessId)
-        {
-            var results = new List<Process>();
-
-            // find processes with the given parent process id
-            var queryText = $"Select ProcessId From Win32_Process Where ParentProcessId = {parentProcessId}";
-            using (var searcher = new ManagementObjectSearcher(queryText))
-            {
-                foreach (var obj in searcher.Get())
-                {
-                    var data = obj.Properties["processid"].Value;
-                    if (data != null)
-                    {
-                        // retrieve the process
-                        var childId = Convert.ToInt32(data);
-                        var childProcess = Process.GetProcessById(childId);
-
-                        // ensure the current process is still alive
-                        if (childProcess != null)
-                        {
-                            results.Add(childProcess);
-                        }
-                    }
-                }
-            }
-
-            return results;
         }
 
         public void StartSeleniumStandaloneServer()

--- a/test/Templates.Test/Helpers/TemplateTestBase.cs
+++ b/test/Templates.Test/Helpers/TemplateTestBase.cs
@@ -11,6 +11,11 @@ using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
+// Turn off parallel test run for Edge as the driver does not support multiple Selenium tests at the same time
+#if EDGE
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
+#endif
+[assembly: TestFramework("Templates.Test.Helpers.XunitExtensions.XunitTestFrameworkWithAssemblyFixture", "Templates.Test")]
 namespace Templates.Test
 {
     public class TemplateTestBase : IDisposable

--- a/test/Templates.Test/Helpers/XunitExtensions/XunitTestAssemblyRunnerWithAssemblyFixture.cs
+++ b/test/Templates.Test/Helpers/XunitExtensions/XunitTestAssemblyRunnerWithAssemblyFixture.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Templates.Test.Helpers.XunitExtensions
+{
+    public class XunitTestAssemblyRunnerWithAssemblyFixture : XunitTestAssemblyRunner
+    {
+        private readonly Dictionary<Type, object> _assemblyFixtureMappings = new Dictionary<Type, object>();
+
+        public XunitTestAssemblyRunnerWithAssemblyFixture(ITestAssembly testAssembly,
+                                                          IEnumerable<IXunitTestCase> testCases,
+                                                          IMessageSink diagnosticMessageSink,
+                                                          IMessageSink executionMessageSink,
+                                                          ITestFrameworkExecutionOptions executionOptions)
+            : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+        {
+        }
+
+        protected override async Task AfterTestAssemblyStartingAsync()
+        {
+            await base.AfterTestAssemblyStartingAsync();
+
+            // Find all the AssemblyFixtureAttributes on the test assembly
+            Aggregator.Run(() =>
+            {
+                var fixturesAttributes = ((IReflectionAssemblyInfo)TestAssembly.Assembly).Assembly
+                                                                                    .GetCustomAttributes(typeof(AssemblyFixtureAttribute), false)
+                                                                                    .Cast<AssemblyFixtureAttribute>()
+                                                                                    .ToList();
+
+                // Instantiate all the fixtures
+                foreach (var fixtureAttribute in fixturesAttributes)
+                {
+                    _assemblyFixtureMappings[fixtureAttribute.FixtureType] = Activator.CreateInstance(fixtureAttribute.FixtureType);
+                }
+            });
+        }
+
+        protected override Task BeforeTestAssemblyFinishedAsync()
+        {
+            // Dispose fixtures
+            foreach (var disposable in _assemblyFixtureMappings.Values.OfType<IDisposable>())
+            {
+                Aggregator.Run(disposable.Dispose);
+            }
+
+            return base.BeforeTestAssemblyFinishedAsync();
+        }
+
+        protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus,
+                                                                   ITestCollection testCollection,
+                                                                   IEnumerable<IXunitTestCase> testCases,
+                                                                   CancellationTokenSource cancellationTokenSource)
+            => new XunitTestCollectionRunnerWithAssemblyFixture(
+                _assemblyFixtureMappings, 
+                testCollection, 
+                testCases, 
+                DiagnosticMessageSink, 
+                messageBus, 
+                TestCaseOrderer, 
+                new ExceptionAggregator(Aggregator), 
+                cancellationTokenSource).RunAsync();
+    }
+}

--- a/test/Templates.Test/Helpers/XunitExtensions/XunitTestCollectionRunnerWithAssemblyFixture.cs
+++ b/test/Templates.Test/Helpers/XunitExtensions/XunitTestCollectionRunnerWithAssemblyFixture.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Templates.Test.Helpers.XunitExtensions
+{
+    public class XunitTestCollectionRunnerWithAssemblyFixture : XunitTestCollectionRunner
+    {
+        private readonly IDictionary<Type, object> _assemblyFixtureMappings;
+        private readonly IMessageSink _diagnosticMessageSink;
+
+        public XunitTestCollectionRunnerWithAssemblyFixture(Dictionary<Type, object> assemblyFixtureMappings,
+                                                            ITestCollection testCollection,
+                                                            IEnumerable<IXunitTestCase> testCases,
+                                                            IMessageSink diagnosticMessageSink,
+                                                            IMessageBus messageBus,
+                                                            ITestCaseOrderer testCaseOrderer,
+                                                            ExceptionAggregator aggregator,
+                                                            CancellationTokenSource cancellationTokenSource)
+            : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+        {
+            _assemblyFixtureMappings = assemblyFixtureMappings;
+            _diagnosticMessageSink = diagnosticMessageSink;
+        }
+
+        protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+        {
+            var runner = new XunitTestClassRunner(
+                testClass,
+                @class,
+                testCases,
+                _diagnosticMessageSink,
+                MessageBus,
+                TestCaseOrderer,
+                new ExceptionAggregator(Aggregator),
+                CancellationTokenSource,
+                _assemblyFixtureMappings);
+
+            return runner.RunAsync();
+        }
+    }
+}

--- a/test/Templates.Test/Helpers/XunitExtensions/XunitTestFrameworkExecutorWithAssemblyFixture.cs
+++ b/test/Templates.Test/Helpers/XunitExtensions/XunitTestFrameworkExecutorWithAssemblyFixture.cs
@@ -18,7 +18,9 @@ namespace Templates.Test.Helpers.XunitExtensions
         protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
         {
             using (var assemblyRunner = new XunitTestAssemblyRunnerWithAssemblyFixture(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+            {
                 await assemblyRunner.RunAsync();
+            }
         }
     }
 }

--- a/test/Templates.Test/Helpers/XunitExtensions/XunitTestFrameworkExecutorWithAssemblyFixture.cs
+++ b/test/Templates.Test/Helpers/XunitExtensions/XunitTestFrameworkExecutorWithAssemblyFixture.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Templates.Test.Helpers.XunitExtensions
+{
+    public class XunitTestFrameworkExecutorWithAssemblyFixture : XunitTestFrameworkExecutor
+    {
+        public XunitTestFrameworkExecutorWithAssemblyFixture(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink)
+            : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
+        {
+        }
+
+        protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+        {
+            using (var assemblyRunner = new XunitTestAssemblyRunnerWithAssemblyFixture(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+                await assemblyRunner.RunAsync();
+        }
+    }
+}

--- a/test/Templates.Test/Helpers/XunitExtensions/XunitTestFrameworkWithAssemblyFixture.cs
+++ b/test/Templates.Test/Helpers/XunitExtensions/XunitTestFrameworkWithAssemblyFixture.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Templates.Test.Helpers.XunitExtensions
+{
+    public class XunitTestFrameworkWithAssemblyFixture : XunitTestFramework
+    {
+        public XunitTestFrameworkWithAssemblyFixture(IMessageSink messageSink)
+            : base(messageSink)
+        {
+        }
+
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+            => new XunitTestFrameworkExecutorWithAssemblyFixture(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+    }
+}

--- a/test/Templates.Test/MvcTemplateTest.cs
+++ b/test/Templates.Test/MvcTemplateTest.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Testing.xunit;
+using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
+[assembly: AssemblyFixture(typeof(SeleniumServerFixture))]
 namespace Templates.Test
 {
     public class MvcTemplateTest : TemplateTestBase

--- a/test/Templates.Test/RazorPagesTemplateTest.cs
+++ b/test/Templates.Test/RazorPagesTemplateTest.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Testing.xunit;
+using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
+[assembly: AssemblyFixture(typeof(SeleniumServerFixture))]
 namespace Templates.Test
 {
     public class RazorPagesTemplateTest : TemplateTestBase

--- a/test/Templates.Test/SpaTemplateTest/AngularTemplateTest.cs
+++ b/test/Templates.Test/SpaTemplateTest/AngularTemplateTest.cs
@@ -1,7 +1,12 @@
-﻿using Microsoft.AspNetCore.Testing.xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Testing.xunit;
+using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
+[assembly: AssemblyFixture(typeof(SeleniumServerFixture))]
 namespace Templates.Test.SpaTemplateTest
 {
     public class AngularTemplateTest : SpaTemplateTestBase

--- a/test/Templates.Test/SpaTemplateTest/ReactReduxTemplateTest.cs
+++ b/test/Templates.Test/SpaTemplateTest/ReactReduxTemplateTest.cs
@@ -1,6 +1,11 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Templates.Test.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 
+[assembly: AssemblyFixture(typeof(SeleniumServerFixture))]
 namespace Templates.Test.SpaTemplateTest
 {
     public class ReactReduxTemplateTest : SpaTemplateTestBase

--- a/test/Templates.Test/SpaTemplateTest/ReactTemplateTest.cs
+++ b/test/Templates.Test/SpaTemplateTest/ReactTemplateTest.cs
@@ -1,6 +1,11 @@
-﻿using Xunit;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Templates.Test.Helpers;
+using Xunit;
 using Xunit.Abstractions;
 
+[assembly: AssemblyFixture(typeof(SeleniumServerFixture))]
 namespace Templates.Test.SpaTemplateTest
 {
     public class ReactTemplateTest : SpaTemplateTestBase

--- a/test/Templates.Test/Templates.Test.csproj
+++ b/test/Templates.Test/Templates.Test.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Selenium.Support" Version="$(SeleniumSupportPackageVersion)" NoWarn="NU1701" />
     <PackageReference Include="Selenium.WebDriver" Version="$(SeleniumWebDriverPackageVersion)" NoWarn="NU1701" />
+    <PackageReference Include="System.Management" Version="$(SystemManagementPackageVersion)" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzersPackageVersion)" />

--- a/test/Templates.Test/Templates.Test.csproj
+++ b/test/Templates.Test/Templates.Test.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
+    <DefineConstants Condition="'$(ASPNETCORE_BROWSER_AUTOMATION_EDGE)' != '' AND '$(ASPNETCORE_BROWSER_AUTOMATION_EDGE)' == 'True'">$(DefineConstants);EDGE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,9 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Process.Sources" Version="$(MicrosoftExtensionsProcessSourcesPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
-    <PackageReference Include="Selenium.Firefox.WebDriver" Version="$(SeleniumFirefoxWebDriverPackageVersion)" />
     <PackageReference Include="Selenium.Support" Version="$(SeleniumSupportPackageVersion)" NoWarn="NU1701" />
-    <PackageReference Include="Selenium.WebDriver.MicrosoftDriver" Version="$(SeleniumWebDriverMicrosoftDriverPackageVersion)" />
     <PackageReference Include="Selenium.WebDriver" Version="$(SeleniumWebDriverPackageVersion)" NoWarn="NU1701" />
     <PackageReference Include="System.Security.Permissions" Version="$(SystemSecurityPermissionsPackageVersion)" />
     <PackageReference Include="xunit" Version="$(XunitPackageVersion)" />

--- a/test/Templates.Test/WebApiTemplateTest.cs
+++ b/test/Templates.Test/WebApiTemplateTest.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Testing.xunit;
+using Templates.Test.Helpers;
 using Xunit;
 using Xunit.Abstractions;
 
+[assembly: AssemblyFixture(typeof(SeleniumServerFixture))]
 namespace Templates.Test
 {
     public class WebApiTemplateTest : TemplateTestBase


### PR DESCRIPTION
Addresses #277 

**In this PR:**

1. Use RemoteWebDriver
2. Use Chrome by default
3. Option to use Firefox or Edge using environment variables
4. Turn off parallel test run for Edge - web driver does not support parallel selenium tests https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5980485/
5. Use AssemblyFixture to set up and tear down the selenium-standalone server and keep test run parallel (sample used https://github.com/xunit/samples.xunit/tree/f4d955a52d3298150ad2bd211c65a3477e184413/AssemblyFixtureExample)

**Note:**
Travis needs installation and Appveyor needs installation and starting the selenium server in yaml files despite the fixture for the tests. 
I have tried running the tests on a clean machine and the fixture takes care of spinning up the server. We plan to move to dotnet-ci bot soon which would not require any configuration.

**Next steps:**

1. Logging for tests: Once the test run starts, there is no logging related to where in the process it is
2. Graceful handling of failures: In case of a failure or interruption in the test run, there needs to be clean up code that stops all the dotnet processes that had begun and close down web drivers and the selenium java process
3. Capture selenium server logs only for failures: May be useful to capture the selenium server logs to debug 

