### PR TITLE
Fixing issue in the react and redux templates where the test is failing

### DIFF
--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/App.test.js
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/App.test.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>, div);
 });

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/package.json
@@ -21,5 +21,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "redux-mock-store": "^1.5.1"
   }
 }

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/App.test.js
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/ClientApp/src/App.test.js
@@ -1,8 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
 import App from './App';
 
 it('renders without crashing', () => {
+  const mockStore = configureStore([])({});
+
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(
+    <Provider store={mockStore}>
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    </Provider>, div);
 });


### PR DESCRIPTION
Currently the javascript test in the React and Redux templates is failing with the following error:

```
 console.error node_modules\fbjs\lib\warning.js:33
   Warning: Failed context type: The context `router` is marked as required in `Link`, but its value is `undefined`.
       in Link (at NavMenu.js:11)
       in NavbarBrand (at NavMenu.js:10)
       in div (created by NavbarHeader)
       in NavbarHeader (at NavMenu.js:9)
       in div (created by Grid)
       in Grid (created by Navbar)
       in nav (created by Navbar)
       in Navbar (created by Uncontrolled(Navbar))
       in Uncontrolled(Navbar) (at NavMenu.js:8)
       in Unknown (at Layout.js:9)
       in div (created by Col)
       in Col (at Layout.js:8)
       in div (created by Row)
       in Row (at Layout.js:7)
       in div (created by Grid)
       in Grid (at Layout.js:6)
       in Unknown (at App.js:9)
       in Unknown (at App.test.js:7)
```

This is because in the test we're trying to render `<App />` with no context of the router. Therefore when trying to render a link the above error is thrown.