### PR TITLE
Prevent 2.1 template tests from corrupting machine state

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -40,12 +40,12 @@
     <MicrosoftVisualStudioWebBrowserLinkPackageVersion>2.1.0</MicrosoftVisualStudioWebBrowserLinkPackageVersion>
     <MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion>2.1.1-rtm-30818</MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
-    <SeleniumFirefoxWebDriverPackageVersion>0.19.0</SeleniumFirefoxWebDriverPackageVersion>
-    <SeleniumSupportPackageVersion>3.7.0</SeleniumSupportPackageVersion>
-    <SeleniumWebDriverMicrosoftDriverPackageVersion>16.16299.0</SeleniumWebDriverMicrosoftDriverPackageVersion>
-    <SeleniumWebDriverPackageVersion>3.7.0</SeleniumWebDriverPackageVersion>
+    <SeleniumFirefoxWebDriverPackageVersion>0.20.0</SeleniumFirefoxWebDriverPackageVersion>
+    <SeleniumSupportPackageVersion>3.12.1</SeleniumSupportPackageVersion>
+    <SeleniumWebDriverMicrosoftDriverPackageVersion>17.17134.0</SeleniumWebDriverMicrosoftDriverPackageVersion>
+    <SeleniumWebDriverPackageVersion>3.12.1</SeleniumWebDriverPackageVersion>
     <SystemSecurityPermissionsPackageVersion>4.5.0</SystemSecurityPermissionsPackageVersion>
-    <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>
+    <XunitAnalyzersPackageVersion>0.9.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>

--- a/test/Templates.Test/Helpers/TemplatePackageInstaller.cs
+++ b/test/Templates.Test/Helpers/TemplatePackageInstaller.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Linq;
 using Microsoft.Extensions.CommandLineUtils;
@@ -21,19 +24,25 @@ namespace Templates.Test.Helpers
             "Microsoft.DotNet.Web.Spa.ProjectTemplates",
         };
 
-        public static void EnsureTemplatePackagesWereReinstalled(ITestOutputHelper output)
+        public static string CustomHivePath { get; } = Path.Combine(AppContext.BaseDirectory, ".templateengine");
+
+        public static void EnsureTemplatingEngineInitialized(ITestOutputHelper output)
         {
             lock (_templatePackagesReinstallationLock)
             {
                 if (!_haveReinstalledTemplatePackages)
                 {
-                    ReinstallTemplatePackages(output);
+                    if (Directory.Exists(CustomHivePath))
+                    {
+                        Directory.Delete(CustomHivePath, recursive: true);
+                    }
+                    InstallTemplatePackages(output);
                     _haveReinstalledTemplatePackages = true;
                 }
             }
         }
 
-        private static void ReinstallTemplatePackages(ITestOutputHelper output)
+        private static void InstallTemplatePackages(ITestOutputHelper output)
         {
             // Remove any previous or prebundled version of the template packages
             foreach (var packageName in _templatePackages)
@@ -42,7 +51,7 @@ namespace Templates.Test.Helpers
                     output,
                     AppContext.BaseDirectory,
                     DotNetMuxer.MuxerPathOrDefault(),
-                    $"new --uninstall {packageName}");
+                    $"new --uninstall {packageName} --debug:custom-hive \"{CustomHivePath}\"");
 
                 // We don't need this command to succeed, because we'll verify next that
                 // uninstallation had the desired effect. This command is expected to fail
@@ -65,7 +74,7 @@ namespace Templates.Test.Helpers
                         output,
                         AppContext.BaseDirectory,
                         DotNetMuxer.MuxerPathOrDefault(),
-                        $"new --install \"{packagePath}\"");
+                        $"new --install \"{packagePath}\" --debug:custom-hive \"{CustomHivePath}\"");
                     proc.WaitForExit(assertSuccess: true);
                 }
             }
@@ -83,7 +92,7 @@ namespace Templates.Test.Helpers
                     output,
                     tempDir,
                     DotNetMuxer.MuxerPathOrDefault(),
-                    $"new \"{templateName}\"");
+                    $"new \"{templateName}\" --debug:custom-hive \"{CustomHivePath}\"");
 
                 proc.WaitForExit(assertSuccess: false);
 

--- a/test/Templates.Test/Helpers/TemplateTestBase.cs
+++ b/test/Templates.Test/Helpers/TemplateTestBase.cs
@@ -25,7 +25,7 @@ namespace Templates.Test
 
         public TemplateTestBase(ITestOutputHelper output)
         {
-            TemplatePackageInstaller.EnsureTemplatePackagesWereReinstalled(output);
+            TemplatePackageInstaller.EnsureTemplatingEngineInitialized(output);
 
             Output = output;
             ProjectGuid = Guid.NewGuid().ToString("N");
@@ -57,16 +57,11 @@ $@"<Project>
             File.WriteAllText(Path.Combine(TemplateOutputDir, "Directory.Build.targets"), directoryBuildTargetsContent);
         }
 
-        protected void InstallTemplatePackages()
-        {
-            throw new NotImplementedException();
-        }
-
         protected void RunDotNetNew(string templateName, string targetFrameworkOverride, string auth = null, string language = null, bool useLocalDB = false, bool noHttps = false)
         {
             SetAfterDirectoryBuildPropsContents();
 
-            var args = $"new {templateName}";
+            var args = $"new {templateName} --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\"";
 
             if (!string.IsNullOrEmpty(targetFrameworkOverride))
             {


### PR DESCRIPTION
Add the `--debug:custom-hive` flag to all usages of `dotnet new`. This instructs the templating engine to use the template config stored in a custom folder instead of defaulting to the machine-global config folder. 

This is a test-only fix that I recommend we put into 2.1 to prevent us from corrupting dev's machine state when they work on templating changes.

Also, upgraded Selenium to support latest Edge update.