### PR TITLE
Rename Web Application to Starter Web Application

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -5,7 +5,7 @@
     "Web",
     "MVC"
   ],
-  "name": "ASP.NET Core Web App (Model-View-Controller)",
+  "name": "ASP.NET Core Starter Web App (Model-View-Controller)",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/vs-2017.3.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/vs-2017.3.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Web Application (Model-View-Controller)",
+    "text": "Starter Web Application (Model-View-Controller)",
     "package": "{0CD94836-1526-4E85-87D3-FB5274C5AFC9}",
     "id": "1015"
   },
@@ -13,7 +13,9 @@
   "order": 300,
   "icon": "vs-2017.3/WebApplication.png",
   "learnMoreLink": "https://go.microsoft.com/fwlink/?LinkID=784881",
-  "uiFilters": [ "oneaspnet" ],
+  "uiFilters": [
+    "oneaspnet"
+  ],
   "supportsDocker": true,
   "isApi": false,
   "usesOidc": true,

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -5,7 +5,7 @@
     "Web",
     "MVC"
   ],
-  "name": "ASP.NET Core Web App (Model-View-Controller)",
+  "name": "ASP.NET Core Starter Web App (Model-View-Controller)",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",


### PR DESCRIPTION
Fixes #584. @danroth27 to confirm that we just wanted to change the display-name, not the shortName, which would be what you typed to create a template. If the shortName need to change too I just need to confirm what it would be called. We could alias it like so:
```json
"shortName": [
  "mvc",
  "starter-mvc"
]
```