### PR TITLE
Remove KoreBuild-isms from project templates

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
@@ -3,14 +3,7 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.2</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <DotNetCoreRuntime Include="${MicrosoftNETCoreApp22PackageVersion}" />
-  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
@@ -3,14 +3,7 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.2</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <DotNetCoreRuntime Include="${MicrosoftNETCoreApp22PackageVersion}" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Startup.fs" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -7,14 +7,8 @@
     <DebugType Condition="'$(TargetFrameworkOverride)' != ''">full</DebugType>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <DotNetCoreRuntime Include="${MicrosoftNETCoreApp22PackageVersion}" />
-  </ItemGroup>
   <!--#if (IndividualLocalAuth && !UseLocalDB) -->
 
   <!--#endif -->

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -7,14 +7,8 @@
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <DotNetCoreRuntime Include="${MicrosoftNETCoreApp22PackageVersion}" />
-  </ItemGroup>
   <!--#if (IndividualLocalAuth && !UseLocalDB) -->
 
   <!--#endif -->

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
@@ -4,14 +4,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.2</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <DotNetCoreRuntime Include="${MicrosoftNETCoreApp22PackageVersion}" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Controllers/HomeController.fs" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -6,14 +6,7 @@
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <DotNetCoreRuntime Include="${MicrosoftNETCoreApp22PackageVersion}" />
-  </ItemGroup>
 
   <ItemGroup>
     <Folder Include="wwwroot\" />

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
@@ -3,14 +3,7 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.2</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
-    <RuntimeFrameworkVersion>${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <DotNetCoreRuntime Include="${MicrosoftNETCoreApp22PackageVersion}" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Include="Controllers/ValuesController.fs" />

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
@@ -11,8 +11,6 @@
 
     <!-- Set this to true if you enable server-side prerendering -->
     <BuildServerSideRenderer>false</BuildServerSideRenderer>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
@@ -8,8 +8,6 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
@@ -8,8 +8,6 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
-    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
-    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">

--- a/test/TemplateTests.props.in
+++ b/test/TemplateTests.props.in
@@ -6,5 +6,7 @@
     <MicrosoftNETSdkRazorPackageVersion>${MicrosoftNETSdkRazorPackageVersion}</MicrosoftNETSdkRazorPackageVersion>
     <BundledAspNetCoreAppTargetFrameworkVersion>${BundledAspNetCoreAppTargetFrameworkVersion}</BundledAspNetCoreAppTargetFrameworkVersion>
     <BundledAspNetCoreAppPackageVersion>${BundledAspNetCoreAppPackageVersion}</BundledAspNetCoreAppPackageVersion>
+    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Removing MSBuild properties and items are for our build infrastructure, not for customers.