### PR TITLE
Import styles in correct order

### DIFF
--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/angular.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/ClientApp/angular.json
@@ -24,8 +24,8 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.css",
-              "node_modules/bootstrap/dist/css/bootstrap.min.css"
+              "node_modules/bootstrap/dist/css/bootstrap.min.css",
+              "src/styles.css"
             ],
             "scripts": []
           },


### PR DESCRIPTION
In the `angular-cli.json` file, the styles.css file should be imported last in the styles section, so the developer can override styles from third party libraries (bootstrap, in this case).

This is just a re-target of #495. All credit to @fredrik-lundin.