### PR TITLE
Update precedence for 2.2 templates

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
   "groupIdentity": "Microsoft.Web.Empty",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.Empty.CSharp.2.2",
   "shortName": "web",
   "tags": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -8,7 +8,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
   "groupIdentity": "Microsoft.Web.Empty",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.Empty.FSharp.2.2",
   "shortName": "web",
   "tags": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -11,7 +11,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a Razor class library that targets .NET Standard",
   "groupIdentity": "Microsoft.Web.Razor",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.Razor.Library.CSharp.2.2",
   "shortName": "razorclasslib",
   "tags": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -10,7 +10,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Razor Pages content",
   "groupIdentity": "Microsoft.Web.RazorPages",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.RazorPages.CSharp.2.2",
   "shortName": [
     "razor",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.Mvc.CSharp.2.2",
   "shortName": "mvc",
   "thirdPartyNotices": "https://aka.ms/aspnetcore-template-3pn-210",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with example ASP.NET Core MVC Views and Controllers. This template can also be used for RESTful HTTP services.",
   "groupIdentity": "Microsoft.Web.Mvc",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.Mvc.FSharp.2.2",
   "shortName": "mvc",
   "thirdPartyNotices": "https://aka.ms/aspnetcore-template-3pn-210",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers.",
   "groupIdentity": "Microsoft.Web.WebApi",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.WebApi.CSharp.2.2",
   "shortName": "webapi",
   "tags": {

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -8,7 +8,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET Core MVC Views and Controllers.",
   "groupIdentity": "Microsoft.Web.WebApi",
-  "precedence": "3000",
+  "precedence": "4000",
   "identity": "Microsoft.Web.WebApi.FSharp.2.2",
   "shortName": "webapi",
   "tags": {


### PR DESCRIPTION
Updates the precedence for 2.2 templates.
When 2.1 and 2.2 templates are installed on the same machine and the templating engine can't differentiate based on the provided parameters the 2.2 templates will be selected.