### PR TITLE
Fix default None items not being removed from ClientApp directory

### DIFF
--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
@@ -28,6 +28,7 @@
   <ItemGroup>
     <!-- Don't publish the SPA source files, but do show them in the project files list -->
     <Content Remove="$(SpaRoot)**" />
+    <None Remove="$(SpaRoot)**" />
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
@@ -25,6 +25,7 @@
   <ItemGroup>
     <!-- Don't publish the SPA source files, but do show them in the project files list -->
     <Content Remove="$(SpaRoot)**" />
+    <None Remove="$(SpaRoot)**" />
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
   </ItemGroup>
 

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
@@ -25,6 +25,7 @@
   <ItemGroup>
     <!-- Don't publish the SPA source files, but do show them in the project files list -->
     <Content Remove="$(SpaRoot)**" />
+    <None Remove="$(SpaRoot)**" />
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
   </ItemGroup>
 


### PR DESCRIPTION
Content MSBuild items from the ClientApp directory are removed from
the project using an MSBuild and then all files are added as None
items. None items that were added by the .NET Core SDK default MSBuild
items were not being removed from the ClientApp directory. This
resulted in duplicate files shown in Visual Studio for Mac. This
affected all the SPA project templates.

Fixes #559