### PR TITLE
Fix template run script

### DIFF
--- a/scripts/Custom-Hive.ps1
+++ b/scripts/Custom-Hive.ps1
@@ -18,8 +18,8 @@ function Test-Template($templateName, $templateArgs, $templateNupkg, $isSPA) {
         $csprojContent = $csprojContent -replace ('<Project Sdk="Microsoft.NET.Sdk.Web">', "<Project Sdk=""Microsoft.NET.Sdk.Web"">`n<Import Project=""$PSScriptRoot/../test/Templates.Test/bin/Debug/netcoreapp2.2/TemplateTests.props"" />")
         $csprojContent | Set-Content $csproj
 
-        dotnet publish
-        dotnet run bin\Release\netcoreapp2.2\publish\tmp.dll
+        dotnet publish --configuration Release
+        dotnet bin\Release\netcoreapp2.2\publish\$templateName.dll
 
     }
     finally {

--- a/scripts/Run-Angular-Locally.ps1
+++ b/scripts/Run-Angular-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Custom-Hive.ps1
 
-Test-Template "angular" "angular" "Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.0-preview2-t000.nupkg" $true
+Test-Template "angular" "angular" "Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.0-preview3-t000.nupkg" $true

--- a/scripts/Run-Razor-Locally.ps1
+++ b/scripts/Run-Razor-Locally.ps1
@@ -6,4 +6,4 @@ param()
 
 . $PSScriptRoot\Custom-Hive.ps1
 
-Test-Template "razor" "razor -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.2.2.2.2.0-preview2-t000.nupkg" $false
+Test-Template "razor" "razor -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.2.2.2.2.0-preview3-t000.nupkg" $false

--- a/scripts/Run-React-Locally.ps1
+++ b/scripts/Run-React-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Custom-Hive.ps1
 
-Test-Template "react" "react" "Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.0-preview2-t000.nupkg" $true
+Test-Template "react" "react" "Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.0-preview3-t000.nupkg" $true

--- a/scripts/Run-ReactRedux-Locally.ps1
+++ b/scripts/Run-ReactRedux-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Custom-Hive.ps1
 
-Test-Template "reactredux" "reactredux" "Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.0-preview2-t000.nupkg" $true
+Test-Template "reactredux" "reactredux" "Microsoft.DotNet.Web.Spa.ProjectTemplates.2.2.0-preview3-t000.nupkg" $true

--- a/scripts/Run-Starterweb-Locally.ps1
+++ b/scripts/Run-Starterweb-Locally.ps1
@@ -9,4 +9,4 @@ $ErrorActionPreference = 'Stop'
 
 . $PSScriptRoot\Custom-Hive.ps1
 
-Test-Template "mvc" "mvc -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.2.2.2.2.0-preview2-t000.nupkg" $false
+Test-Template "mvc" "mvc -au Individual" "Microsoft.DotNet.Web.ProjectTemplates.2.2.2.2.0-preview3-t000.nupkg" $false


### PR DESCRIPTION
This solves three issues:

1. We now publish Release. I was under the impression that `dotnet publish` automatically set the config to Release, but this is not the case.
2. We actually call the published dll. Before we had `dotnet run dllPath`, which at first glance looks like it will run the published dll but actually just runs the site normally, passing the dll path as an unused parameter.
3. Update the package name in our scripts. 