### PR TITLE
Include Razor.Design dep that was missing in master

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -20,6 +20,7 @@
     <MicrosoftAspNetCoreIdentityUIPackageVersion>3.0.0-alpha1-10549</MicrosoftAspNetCoreIdentityUIPackageVersion>
     <MicrosoftAspNetCoreMvcPackageVersion>3.0.0-alpha1-10549</MicrosoftAspNetCoreMvcPackageVersion>
     <MicrosoftAspNetCorePackageVersion>3.0.0-alpha1-10549</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftAspNetCoreRazorDesignPackageVersion>3.0.0-alpha1-10549</MicrosoftAspNetCoreRazorDesignPackageVersion>
     <MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion>3.0.0-alpha1-10549</MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion>
     <MicrosoftAspNetCoreSpaServicesPackageVersion>3.0.0-alpha1-10549</MicrosoftAspNetCoreSpaServicesPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>3.0.0-alpha1-10549</MicrosoftAspNetCoreStaticFilesPackageVersion>


### PR DESCRIPTION
It probably got lost in a merge somewhere. It's only used by the tests. Already exists in release/2.2.