### PR TITLE
Update to new templates

### DIFF
--- a/.vsts-pipelines/templates/project-ci.yml
+++ b/.vsts-pipelines/templates/project-ci.yml
@@ -1,7 +1,7 @@
 # See https://github.com/aspnet/BuildTools
 
 phases:
-- template: .vsts-pipelines/templates/phases/default-build.yml@buildtools
+- template: .azure/templates/jobs/default-build.yml@buildtools
   parameters:
     agentOs: Windows
     beforeBuild:
@@ -10,7 +10,7 @@ phases:
       inputs:
         versionSpec: 8.x
 
-- template: .vsts-pipelines/templates/phases/default-build.yml@buildtools
+- template: .azure/templates/jobs/default-build.yml@buildtools
   parameters:
     agentOs: macOS
     beforeBuild:
@@ -24,7 +24,7 @@ phases:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
   
-- template: .vsts-pipelines/templates/phases/default-build.yml@buildtools
+- template: .azure/templates/jobs/default-build.yml@buildtools
   parameters:
     agentOs: Linux
     beforeBuild:


### PR DESCRIPTION
We see this message in VSTS builds: `This build template is obsolete and will be removed in the future. Please update your schema to use the  .azure/templates/jobs/default-build.yml template`. So let's fix it.