### PR TITLE
Remove .NET Framework project templates

### DIFF
--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-CSharp.csproj.in
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
-    <AspNetCoreHostingModel Condition="'$(TargetFrameworkOverride)' == ''">InProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/EmptyWeb-FSharp.fsproj.in
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
-    <AspNetCoreHostingModel Condition="'$(TargetFrameworkOverride)' == ''">InProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
@@ -13,11 +12,8 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/RazorPagesWeb-CSharp.csproj.in
@@ -1,14 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-0ce56475-d1db-490f-8af1-a881ea4fcd2d</UserSecretsId>
-    <DebugType Condition="'$(TargetFrameworkOverride)' != ''">full</DebugType>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
-    <AspNetCoreHostingModel Condition="'$(TargetFrameworkOverride)' == ''">InProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
@@ -19,27 +17,11 @@
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqlitePackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="${MicrosoftAspNetCoreCookiePolicyPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(RequiresHttps)' == 'True'"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqlitePackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerPackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsPackageVersion}" PrivateAssets="All" Condition="'$(IndividualLocalAuth)' == 'True'" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-CSharp.csproj.in
@@ -1,14 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
-    <DebugType Condition="'$(TargetFrameworkOverride)' != ''">full</DebugType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
-    <AspNetCoreHostingModel Condition="'$(TargetFrameworkOverride)' == ''">InProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
@@ -19,27 +17,11 @@
     <None Update="app.db" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqlitePackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="${MicrosoftAspNetCoreCookiePolicyPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(RequiresHttps)' == 'True'"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}" Condition="'$(IndividualLocalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="${MicrosoftEntityFrameworkCoreSqlitePackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' != 'True'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="${MicrosoftEntityFrameworkCoreSqlServerPackageVersion}" Condition=" '$(IndividualLocalAuth)' == 'True' AND '$(UseLocalDB)' == 'True'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="${MicrosoftEntityFrameworkCoreToolsPackageVersion}" PrivateAssets="All" Condition="'$(IndividualLocalAuth)' == 'True'" />
-  </ItemGroup>
-
+  
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/StarterWeb-FSharp.fsproj.in
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
-    <AspNetCoreHostingModel Condition="'$(TargetFrameworkOverride)' == ''">InProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
@@ -16,15 +15,8 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.CookiePolicy" Version="${MicrosoftAspNetCoreCookiePolicyPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(NoHttps)' != 'True'"/>
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-CSharp.csproj.in
@@ -1,27 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <UserSecretsId Condition="'$(IndividualAuth)' == 'True' OR '$(OrganizationalAuth)' == 'True'">aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' != 'True'">0</WebProject_DirectoryAccessLevelKey>
     <WebProject_DirectoryAccessLevelKey Condition="'$(OrganizationalAuth)' == 'True' AND '$(OrgReadAccess)' == 'True'">1</WebProject_DirectoryAccessLevelKey>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
-    <AspNetCoreHostingModel Condition="'$(TargetFrameworkOverride)' == ''">InProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADUIPackageVersion}" Condition="'$(OrganizationalAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="${MicrosoftAspNetCoreAuthenticationAzureADB2CUIPackageVersion}" Condition="'$(IndividualB2CAuth)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(RequiresHttps)' == 'True'" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/WebApi-FSharp.fsproj.in
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <NoDefaultLaunchSettingsFile Condition="'$(ExcludeLaunchSettings)' == 'True'">True</NoDefaultLaunchSettingsFile>
-    <AspNetCoreHostingModel Condition="'$(TargetFrameworkOverride)' == ''">InProcess</AspNetCoreHostingModel>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
@@ -14,13 +13,8 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(NoHttps)' != 'True'" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     },

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -25,12 +25,6 @@
     {
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
@@ -85,13 +79,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/app.config
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     },

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/.template.config/template.json
@@ -21,12 +21,6 @@
     {
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
@@ -81,13 +75,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/app.config
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-FSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": true,
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework",
       "isHidden": true
@@ -16,4 +11,3 @@
     }
   }
 }
-g

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorClassLibrary-CSharp/.template.config/template.json
@@ -21,13 +21,6 @@
   "sourceName": "Company.RazorClassLibrary1",
   "preferNameDirectory": true,
   "symbols": {
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
-    },
     "Framework": {
       "type": "parameter",
       "description": "The target framework for the project.",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "UseLocalDB": {
       "longName": "use-local-db"
     },

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/.template.config/template.json
@@ -34,12 +34,6 @@
       ],
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(!OrganizationalAuth && !IndividualAuth)",
           "exclude": [
             "Pages/Shared/_LoginPartial.Identity.cshtml",
@@ -309,13 +303,6 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified."
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/app.config
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/RazorPagesWeb-CSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "UseLocalDB": {
       "longName": "use-local-db"
     },

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -30,12 +30,6 @@
       ],
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(!OrganizationalAuth && !IndividualAuth)",
           "exclude": [
             "Views/Shared/_LoginPartial.Identity.cshtml",
@@ -299,13 +293,6 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified."
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/app.config
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -11,11 +11,6 @@
       "longName": "exclude-launch-settings",
       "shortName": ""
     },
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     },

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -26,12 +26,6 @@
       ],
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
@@ -86,13 +80,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/app.config
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "UseLocalDB": {
       "longName": "use-local-db"
     },

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -26,12 +26,6 @@
     {
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(windir == 'C:\\Windows')",
           "exclude": [
             "Properties/launchSettings.json"
@@ -208,13 +202,6 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified."
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/app.config
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/dotnetcli.host.json
@@ -11,11 +11,6 @@
       "longName": "exclude-launch-settings",
       "shortName": ""
     },
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     },

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/.template.config/template.json
@@ -21,12 +21,6 @@
     {
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
@@ -81,13 +75,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/app.config
+++ b/src/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-FSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/Angular-CSharp.csproj.in
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>
@@ -15,16 +14,8 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(NoHttps)' != 'True'"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/React-CSharp.csproj.in
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>
@@ -12,16 +11,8 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(NoHttps)' != 'True'"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/ReactRedux-CSharp.csproj.in
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
     <IsPackable>false</IsPackable>
@@ -12,16 +11,8 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' == ''">
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkOverride)' != ''">
-    <PackageReference Include="Microsoft.AspNetCore" Version="${MicrosoftAspNetCorePackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="${MicrosoftAspNetCoreHttpsPolicyPackageVersion}" Condition="'$(NoHttps)' != 'True'"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="${MicrosoftAspNetCoreMvcPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices" Version="${MicrosoftAspNetCoreSpaServicesPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="${MicrosoftAspNetCoreSpaServicesExtensionsPackageVersion}" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="${MicrosoftAspNetCoreStaticFilesPackageVersion}" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     },

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/.template.config/template.json
@@ -25,12 +25,6 @@
       ],
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
@@ -85,13 +79,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/app.config
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/Angular-CSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     },

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/.template.config/template.json
@@ -25,12 +25,6 @@
       ],
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
@@ -85,13 +79,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/app.config
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/React-CSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/dotnetcli.host.json
@@ -1,11 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/dotnetcli.host",
   "symbolInfo": {
-    "TargetFrameworkOverride": {
-      "isHidden": "true",
-      "longName": "target-framework-override",
-      "shortName": ""
-    },
     "Framework": {
       "longName": "framework"
     },

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/.template.config/template.json
@@ -25,12 +25,6 @@
       ],
       "modifiers": [
         {
-          "condition": "(TargetFrameworkOverride == '')",
-          "exclude": [
-            "app.config"
-          ]
-        },
-        {
           "condition": "(ExcludeLaunchSettings)",
           "exclude": [
             "Properties/launchSettings.json"
@@ -85,13 +79,6 @@
         "fallbackVariableName": "HttpsPortGenerated"
       },
       "replaces": "44300"
-    },
-    "TargetFrameworkOverride": {
-      "type": "parameter",
-      "description": "Overrides the target framework",
-      "replaces": "TargetFrameworkOverride",
-      "datatype": "string",
-      "defaultValue": ""
     },
     "Framework": {
       "type": "parameter",

--- a/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/app.config
+++ b/src/Microsoft.DotNet.Web.Spa.ProjectTemplates/content/ReactRedux-CSharp/app.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <gcServer enabled="true"/>
-  </runtime>
-</configuration>

--- a/test/Templates.Test/EmptyWebTemplateTest.cs
+++ b/test/Templates.Test/EmptyWebTemplateTest.cs
@@ -13,23 +13,14 @@ namespace Templates.Test
         {
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
-        public void EmptyWebTemplate_Works_NetFramework()
-            => EmptyWebTemplateImpl("net461");
-
         [Fact]
-        public void EmptyWebTemplate_Works_NetCore()
-            => EmptyWebTemplateImpl(null);
-
-        private void EmptyWebTemplateImpl(string targetFrameworkOverride)
+        public void EmptyWebTemplate()
         {
-            RunDotNetNew("web", targetFrameworkOverride);
+            RunDotNetNew("web");
 
             foreach (var publish in new[] { false, true })
             {
-                using (var aspNetProcess = StartAspNetProcess(targetFrameworkOverride, publish))
+                using (var aspNetProcess = StartAspNetProcess(publish))
                 {
                     aspNetProcess.AssertOk("/");
                 }

--- a/test/Templates.Test/Helpers/TemplateTestBase.cs
+++ b/test/Templates.Test/Helpers/TemplateTestBase.cs
@@ -59,16 +59,11 @@ $@"<Project>
             File.WriteAllText(Path.Combine(TemplateOutputDir, "Directory.Build.targets"), directoryBuildTargetsContent);
         }
 
-        protected void RunDotNetNew(string templateName, string targetFrameworkOverride, string auth = null, string language = null, bool useLocalDB = false, bool noHttps = false)
+        protected void RunDotNetNew(string templateName, string auth = null, string language = null, bool useLocalDB = false, bool noHttps = false)
         {
             SetAfterDirectoryBuildPropsContents();
 
             var args = $"new {templateName} --debug:custom-hive \"{TemplatePackageInstaller.CustomHivePath}\"";
-
-            if (!string.IsNullOrEmpty(targetFrameworkOverride))
-            {
-                args += $" --target-framework-override {targetFrameworkOverride}";
-            }
 
             if (!string.IsNullOrEmpty(auth))
             {
@@ -214,9 +209,9 @@ $@"<Project>
             return File.ReadAllText(Path.Combine(TemplateOutputDir, path));
         }
 
-        protected AspNetProcess StartAspNetProcess(string targetFrameworkOverride, bool publish = false)
+        protected AspNetProcess StartAspNetProcess(bool publish = false)
         {
-            return new AspNetProcess(Output, TemplateOutputDir, ProjectName, targetFrameworkOverride, publish);
+            return new AspNetProcess(Output, TemplateOutputDir, ProjectName, publish);
         }
 
         public void Dispose()

--- a/test/Templates.Test/SpaTemplateTest/AngularTemplateTest.cs
+++ b/test/Templates.Test/SpaTemplateTest/AngularTemplateTest.cs
@@ -15,20 +15,8 @@ namespace Templates.Test.SpaTemplateTest
         {
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
-        // Just use 'angular' as representative for .NET 4.6.1 coverage, as
-        // the client-side code isn't affected by the .NET runtime choice
-        public void AngularTemplate_Works_NetFramework()
-            => SpaTemplateImpl("net461", "angular");
-
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux | OperatingSystems.MacOSX)]
-        public void AngularTemplate_NoHttps_Works_NetFramework()
-            => SpaTemplateImpl("net461", "angular", true);
-
         [Fact]
-        public void AngularTemplate_Works_NetCore()
-            => SpaTemplateImpl(null, "angular");
+        public void AngularTemplate_Works()
+            => SpaTemplateImpl("angular");
     }
 }

--- a/test/Templates.Test/SpaTemplateTest/ReactReduxTemplateTest.cs
+++ b/test/Templates.Test/SpaTemplateTest/ReactReduxTemplateTest.cs
@@ -16,6 +16,6 @@ namespace Templates.Test.SpaTemplateTest
 
         [Fact]
         public void ReactReduxTemplate_Works_NetCore()
-            => SpaTemplateImpl(null, "reactredux");
+            => SpaTemplateImpl("reactredux");
     }
 }

--- a/test/Templates.Test/SpaTemplateTest/ReactTemplateTest.cs
+++ b/test/Templates.Test/SpaTemplateTest/ReactTemplateTest.cs
@@ -16,6 +16,6 @@ namespace Templates.Test.SpaTemplateTest
 
         [Fact]
         public void ReactTemplate_Works_NetCore()
-            => SpaTemplateImpl(null, "react");
+            => SpaTemplateImpl("react");
     }
 }

--- a/test/Templates.Test/SpaTemplateTest/SpaTemplateTestBase.cs
+++ b/test/Templates.Test/SpaTemplateTest/SpaTemplateTestBase.cs
@@ -25,9 +25,9 @@ namespace Templates.Test.SpaTemplateTest
         // Rather than using [Theory] to pass each of the different values for 'template',
         // it's important to distribute the SPA template tests over different test classes
         // so they can be run in parallel. Xunit doesn't parallelize within a test class.
-        protected void SpaTemplateImpl(string targetFrameworkOverride, string template, bool noHttps = false)
+        protected void SpaTemplateImpl(string template, bool noHttps = false)
         {
-            RunDotNetNew(template, targetFrameworkOverride, noHttps: noHttps);
+            RunDotNetNew(template, noHttps: noHttps);
 
             // For some SPA templates, the NPM root directory is './ClientApp'. In other
             // templates it's at the project root. Strictly speaking we shouldn't have
@@ -41,13 +41,13 @@ namespace Templates.Test.SpaTemplateTest
             Npm.RestoreWithRetry(Output, clientAppSubdirPath);
             Npm.Test(Output, clientAppSubdirPath);
 
-            TestApplication(targetFrameworkOverride, publish: false);
-            TestApplication(targetFrameworkOverride, publish: true);
+            TestApplication(publish: false);
+            TestApplication(publish: true);
         }
 
-        private void TestApplication(string targetFrameworkOverride, bool publish)
+        private void TestApplication(bool publish)
         {
-            using (var aspNetProcess = StartAspNetProcess(targetFrameworkOverride, publish))
+            using (var aspNetProcess = StartAspNetProcess(publish))
             {
                 aspNetProcess.AssertStatusCode("/", HttpStatusCode.OK, "text/html");
 

--- a/test/Templates.Test/Templates.Test.csproj
+++ b/test/Templates.Test/Templates.Test.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <DefineConstants>$(DefineConstants);XPLAT</DefineConstants>
-    
-    <!-- Workaround until https://github.com/aspnet/Common/pull/385 is done -->
-    <DefineConstants>$(DefineConstants);NETCOREAPP2_2</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Templates.Test/WebApiTemplateTest.cs
+++ b/test/Templates.Test/WebApiTemplateTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Testing.xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -13,23 +12,14 @@ namespace Templates.Test
         {
         }
 
-        [ConditionalFact]
-        [OSSkipCondition(OperatingSystems.Linux)]
-        [OSSkipCondition(OperatingSystems.MacOSX)]
-        public void WebApiTemplate_Works_NetFramework()
-            => WebApiTemplateImpl("net461");
-
         [Fact]
-        public void WebApiTemplate_Works_NetCore()
-            => WebApiTemplateImpl(null);
-
-        private void WebApiTemplateImpl(string targetFrameworkOverride)
+        public void WebApiTemplate()
         {
-            RunDotNetNew("webapi", targetFrameworkOverride);
+            RunDotNetNew("webapi");
 
             foreach (var publish in new[] { false, true })
             {
-                using (var aspNetProcess = StartAspNetProcess(targetFrameworkOverride, publish))
+                using (var aspNetProcess = StartAspNetProcess(publish))
                 {
                     aspNetProcess.AssertOk("/api/values");
                     aspNetProcess.AssertNotFound("/");


### PR DESCRIPTION
As announced in https://github.com/aspnet/Announcements/issues/324, ASP.NET Core will not support running on .NET Framework. This removes the .NET Framework templates completely.